### PR TITLE
Fix merged mining: embed aux merkle root in coinbase

### DIFF
--- a/src/blockchain/blockTemplate.js
+++ b/src/blockchain/blockTemplate.js
@@ -27,6 +27,7 @@ class BlockTemplateManager extends EventEmitter {
     super();
     this.rpc = rpcClient;
     this.poolConfig = poolConfig;
+    this.auxPowEngine = poolConfig.auxPowEngine || null;
 
     this.currentTemplate = null;
     this.currentJobId = null;
@@ -255,12 +256,18 @@ class BlockTemplateManager extends EventEmitter {
     // Coinbase script (scriptSig)
     // Block height serialization (BIP34)
     const heightBuf = this._serializeBlockHeight(template.height);
-    
+
     // Pool tag
     const poolTag = Buffer.from(`/LUXXPOOL/${template.height}/${this.currentJobId}/`, 'ascii');
-    
-    // scriptSig = height + poolTag + [EXTRANONCE GOES HERE]
-    const scriptSigPre = Buffer.concat([heightBuf, poolTag]);
+
+    // Merged mining: embed aux merkle root in coinbase scriptSig
+    // Format: fabe6d6d + auxMerkleRoot(32) + merkleSize(4) + merkleNonce(4) = 44 bytes
+    const auxData = this.auxPowEngine ? this.auxPowEngine.getCoinbaseAuxData() : null;
+
+    // scriptSig = height + poolTag + [auxData] + [EXTRANONCE GOES HERE]
+    const scriptSigPre = auxData
+      ? Buffer.concat([heightBuf, poolTag, auxData])
+      : Buffer.concat([heightBuf, poolTag]);
     const scriptSigLen = scriptSigPre.length + this.extraNonce1Size + this.extraNonce2Size;
 
     parts.push(serializeVarInt(scriptSigLen));

--- a/src/index.js
+++ b/src/index.js
@@ -192,6 +192,17 @@ async function main() {
     }
   });
 
+  // Merged mining: rebuild template when aux blocks change so the
+  // new aux merkle root is embedded in the next coinbase scriptSig.
+  auxPowEngine.on('newAuxBlock', async (symbol) => {
+    try {
+      await templateManager.updateTemplate();
+      log.debug({ coin: symbol }, 'Template refreshed for aux block update');
+    } catch (err) {
+      log.error({ coin: symbol, err: err.message }, 'Template refresh on aux block failed');
+    }
+  });
+
   await blockNotifier.start();
 
   // Also poll every 5s as safety net (ZMQ is primary, poll is backup)
@@ -538,7 +549,7 @@ async function main() {
   // WIRING: Share Results → Security + Hashrate
   // ═══════════════════════════════════════════════════════
 
-  shareProcessor.on('validShare', (client, share) => {
+  shareProcessor.on('validShare', (client, share, auxProof) => {
     if (!client._isFleet) {
       banningManager.recordValidShare(client.remoteAddress);
       // L4 fingerprinting now handled by SecurityEngine.onShare()
@@ -553,6 +564,17 @@ async function main() {
       hashrate: client.hashrate,
       validShares: (fleetManager.fleetMiners.get(client.id)?.validShares || 0) + 1,
     });
+
+    // ── Merged mining: check share against all aux chain targets ──
+    if (auxProof && auxPowEngine) {
+      auxPowEngine.checkAuxChains(
+        auxProof.hash,
+        auxProof.headerBuffer,
+        auxProof.coinbaseHex,
+        auxProof.merkleBranches,
+        client
+      ).catch(err => log.error({ err: err.message }, 'AuxPoW check error'));
+    }
   });
 
   shareProcessor.on('invalidShare', (client, share, reason) => {

--- a/src/pool/shareProcessor.js
+++ b/src/pool/shareProcessor.js
@@ -128,7 +128,7 @@ class ShareProcessor extends EventEmitter {
       // ── Step 7: Record share ──
       await this._recordShare(client, share, template);
 
-      // ── Step 8: Check for block solution ──
+      // ── Step 8: Check for block solution (LTC parent chain) ──
       const networkTarget = bitsToTarget(template.bits);
       if (meetsTarget(hash, networkTarget)) {
         log.info({
@@ -141,7 +141,16 @@ class ShareProcessor extends EventEmitter {
         await this._submitBlock(template, headerBuffer, extraNonce1, extraNonce2, ntime, nonce, client, jobId);
       }
 
-      this.emit('validShare', client, share);
+      // ── Step 9: Emit valid share with aux-proof data for merged mining ──
+      // Aux chains have lower difficulty — every valid share could solve an aux block.
+      const job = this.templateManager.getJob(jobId);
+      const { coinbaseHex } = this.templateManager.buildCoinbaseForJob(jobId, extraNonce1, extraNonce2);
+      this.emit('validShare', client, share, {
+        hash,
+        headerBuffer,
+        coinbaseHex,
+        merkleBranches: job ? job.merkleBranches : [],
+      });
 
     } catch (err) {
       log.error({ err: err.message, worker: client.workerName }, 'Share processing error');


### PR DESCRIPTION
## Summary
- Embed aux merkle root (`fabe6d6d` + 32-byte root + tree metadata) in coinbase scriptSig — was never wired
- Emit aux-proof data on every valid share so aux chain targets are checked
- Wire `auxPowEngine.checkAuxChains()` to submit aux blocks when share meets aux difficulty
- Rebuild templates on `newAuxBlock` events so miners always mine with fresh aux merkle roots

**Without this fix, merged mining for all 9 aux chains silently fails** — aux daemons cannot find the merged mining proof in the parent coinbase.

## Test plan
- [x] All 141 tests pass
- [x] `getCoinbaseAuxData()` called during coinbase construction
- [x] `checkAuxChains()` wired to validShare event
- [x] Template refreshes on aux block updates

https://claude.ai/code/session_01FBvGZ7v3NgzhbJJtDkK6jW