### PR TITLE
v0.8.2: Logging & Alert System + ASIC Registry Expansion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,29 @@ SEC_MAX_CONN_PER_IP=5                     # Public: connections per IP
 SEC_MAX_CONN_PER_FLEET_IP=100             # Fleet: connections per IP
 SEC_MAX_SHARE_RATE_PER_MIN=600            # Shares/min per client
 DDOS_MAX_CONNECTIONS_PER_IP=5             # Stratum-level public limit
+
+# ─── Alert Delivery (v0.8.2) ─────────────────────────────────────────────────
+# Minimum minutes between repeated alerts for the same event+chain
+ALERT_COOLDOWN_MINUTES=5
+
+# Email alerts via SMTP
+ALERT_EMAIL_ENABLED=false
+ALERT_SMTP_HOST=smtp.gmail.com
+ALERT_SMTP_PORT=587
+ALERT_SMTP_USER=your@gmail.com
+ALERT_SMTP_PASS=                          # Gmail: use an App Password (not your account password)
+ALERT_EMAIL_FROM=luxxpool@yourdomain.com
+ALERT_EMAIL_TO=your@personal-email.com    # where to receive alerts
+
+# Telegram alerts
+ALERT_TELEGRAM_ENABLED=false
+ALERT_TELEGRAM_BOT_TOKEN=                 # get from @BotFather on Telegram
+ALERT_TELEGRAM_CHAT_ID=                   # your personal chat ID or group ID
+
+# Generic webhook (POST JSON to any URL)
+ALERT_WEBHOOK_ENABLED=false
+ALERT_WEBHOOK_URL=
+ALERT_WEBHOOK_SECRET=
+
+# ─── Logging ─────────────────────────────────────────────────────────────────
+LOG_LEVEL=info                            # pino level: trace|debug|info|warn|error

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -39,8 +39,8 @@ services:
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "5"
+        max-size: "100m"   # v0.8.2: increased from 50m — event log is verbose
+        max-file: "10"     # v0.8.2: increased from 5
     volumes:
       - pool-logs:/var/log/luxxpool
       # Mount SSL certs if using stratum+ssl

--- a/migrations/012_pool_events.js
+++ b/migrations/012_pool_events.js
@@ -1,0 +1,106 @@
+/**
+ * LUXXPOOL — Migration 012: pool_events table + views + pruning function
+ * Adds the persistent event log for the v0.8.2 logging & alert system.
+ */
+
+const MIGRATION_SQL = `
+
+CREATE TABLE IF NOT EXISTS pool_events (
+  id           BIGSERIAL     PRIMARY KEY,
+  code         VARCHAR(16)   NOT NULL,
+  category     VARCHAR(32)   NOT NULL,
+  severity     VARCHAR(16)   NOT NULL,
+  chain        VARCHAR(16),
+  address      VARCHAR(64),
+  worker       VARCHAR(64),
+  diff         NUMERIC(20,0),
+  block_height BIGINT,
+  txid         VARCHAR(128),
+  error_msg    TEXT,
+  meta         JSONB         NOT NULL DEFAULT '{}',
+  created_at   TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pool_events_code     ON pool_events (code);
+CREATE INDEX IF NOT EXISTS idx_pool_events_category ON pool_events (category);
+CREATE INDEX IF NOT EXISTS idx_pool_events_severity ON pool_events (severity);
+CREATE INDEX IF NOT EXISTS idx_pool_events_chain    ON pool_events (chain);
+CREATE INDEX IF NOT EXISTS idx_pool_events_address  ON pool_events (address) WHERE address IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_pool_events_created  ON pool_events (created_at DESC);
+
+-- Recent errors (last 24h, error/critical only)
+CREATE OR REPLACE VIEW v_recent_errors AS
+  SELECT id, code, category, severity, chain, error_msg, meta, created_at
+  FROM pool_events
+  WHERE severity IN ('error', 'critical')
+    AND created_at > NOW() - INTERVAL '24 hours'
+  ORDER BY created_at DESC;
+
+-- Event counts by code in last 1h
+CREATE OR REPLACE VIEW v_event_summary_1h AS
+  SELECT code, category, severity, COUNT(*) AS cnt
+  FROM pool_events
+  WHERE created_at > NOW() - INTERVAL '1 hour'
+  GROUP BY code, category, severity
+  ORDER BY cnt DESC;
+
+-- Block history (submitted/accepted/rejected/orphaned)
+CREATE OR REPLACE VIEW v_block_history AS
+  SELECT id, code, chain, block_height,
+         meta->>'hash'   AS hash,
+         (meta->>'reward')::NUMERIC AS reward,
+         error_msg,
+         created_at
+  FROM pool_events
+  WHERE code IN ('BLOCK_001', 'BLOCK_002', 'BLOCK_003', 'BLOCK_004')
+  ORDER BY created_at DESC;
+
+-- Payment log (LTC sent, aux sent, failures)
+CREATE OR REPLACE VIEW v_payment_log AS
+  SELECT id, code, chain, address, txid,
+         (meta->>'amount')::NUMERIC AS amount,
+         error_msg,
+         created_at
+  FROM pool_events
+  WHERE code IN ('PAY_003', 'PAY_004', 'PAY_005')
+  ORDER BY created_at DESC;
+
+-- Security log (all security-category events)
+CREATE OR REPLACE VIEW v_security_log AS
+  SELECT id, code, severity, chain, address, meta, created_at
+  FROM pool_events
+  WHERE category = 'security'
+  ORDER BY created_at DESC;
+
+-- Pruning function
+-- Retention policy:
+--   - Keep block/payment events forever
+--   - Prune info/warn (non-block/payment) older than 14 days
+--   - Prune error/critical (non-block/payment) older than 90 days
+CREATE OR REPLACE FUNCTION pool_events_prune()
+RETURNS TABLE(pruned_info_warn BIGINT, pruned_errors BIGINT) AS $$
+DECLARE
+  v_iw BIGINT;
+  v_er BIGINT;
+BEGIN
+  DELETE FROM pool_events
+   WHERE category NOT IN ('block', 'payment')
+     AND severity IN ('info', 'warn')
+     AND created_at < NOW() - INTERVAL '14 days';
+  GET DIAGNOSTICS v_iw = ROW_COUNT;
+
+  DELETE FROM pool_events
+   WHERE category NOT IN ('block', 'payment')
+     AND severity IN ('error', 'critical')
+     AND created_at < NOW() - INTERVAL '90 days';
+  GET DIAGNOSTICS v_er = ROW_COUNT;
+
+  pruned_info_warn := v_iw;
+  pruned_errors := v_er;
+  RETURN NEXT;
+END;
+$$ LANGUAGE plpgsql;
+
+`;
+
+module.exports = { MIGRATION_SQL };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,12 @@
         "ioredis": "^5.4.1",
         "merkle-lib": "^2.0.10",
         "multihashing-async": "^2.1.4",
+        "nodemailer": "^6.10.1",
         "pg": "^8.13.0",
         "pg-pool": "^3.7.0",
         "pino": "^9.14.0",
         "pino-pretty": "^13.0.0",
+        "prom-client": "^15.1.3",
         "uuid": "^10.0.0",
         "ws": "^8.18.0"
       },
@@ -1302,6 +1304,15 @@
       "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==",
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -1774,6 +1785,12 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/blakejs": {
       "version": "1.2.1",
@@ -4773,6 +4790,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.14",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
@@ -5522,6 +5548,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6260,6 +6299,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luxxpool",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "LUXXPOOL — Enterprise Litecoin & Dogecoin Merged Mining Pool",
   "main": "src/index.js",
   "scripts": {
@@ -26,10 +26,12 @@
     "ioredis": "^5.4.1",
     "merkle-lib": "^2.0.10",
     "multihashing-async": "^2.1.4",
+    "nodemailer": "^6.10.1",
     "pg": "^8.13.0",
     "pg-pool": "^3.7.0",
     "pino": "^9.14.0",
     "pino-pretty": "^13.0.0",
+    "prom-client": "^15.1.3",
     "uuid": "^10.0.0",
     "ws": "^8.18.0"
   },

--- a/src/api/routes/extended.js
+++ b/src/api/routes/extended.js
@@ -5,7 +5,7 @@ const { API } = require('../../ux/copy');
  */
 
 const { createLogger } = require('../../utils/logger');
-const { SCRYPT_COINS } = require('../../config/coins');
+const { SCRYPT_COINS } = require('../../../config/coins');
 const HashrateEstimator = require('../../monitoring/hashrateEstimator');
 
 const log = createLogger('api:ext');

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -9,6 +9,8 @@ const helmet = require('helmet');
 const compression = require('compression');
 const rateLimit = require('express-rate-limit');
 const { createLogger } = require('../utils/logger');
+const poolLogger = require('../logging/poolLogger');
+const minerRegistry = require('../pool/minerRegistry');
 const { registerExtendedRoutes } = require('./routes/extended');
 const { registerSecurityRoutes } = require('./routes/security');
 const { registerPoolRoutes } = require('./routes/pool');
@@ -284,6 +286,12 @@ function createApiServer(deps) {
   // ── Dashboard Routes (v0.7.0) ──
   registerDashboardRoutes(app, deps);
 
+  // ── v0.8.2: ASIC model catalog ──
+  app.get('/api/v1/models', (req, res) => {
+    const models = minerRegistry.listModels();
+    res.json({ count: models.length, models });
+  });
+
   // ── 404 ──
   app.use((req, res) => {
     res.status(API.errors.NOT_FOUND.status).json(API.errors.NOT_FOUND);
@@ -292,6 +300,7 @@ function createApiServer(deps) {
   // ── Error handler ──
   app.use((err, req, res, _next) => {
     log.error({ err: err.message, path: req.path }, 'Unhandled API error');
+    try { poolLogger.emit('SYS_008', { route: req.path, error: err.message }); } catch {}
     res.status(API.errors.INTERNAL.status).json(API.errors.INTERNAL);
   });
 

--- a/src/blockchain/auxpow.js
+++ b/src/blockchain/auxpow.js
@@ -15,6 +15,7 @@
 const crypto = require('crypto');
 const EventEmitter = require('events');
 const { createLogger } = require('../utils/logger');
+const poolLogger = require('../logging/poolLogger');
 const { sha256d, reverseBuffer, reverseHex } = require('../utils/hashing');
 const RpcClient = require('./rpcClient');
 const { getAuxChains } = require('../../config/coins');
@@ -231,6 +232,8 @@ class AuxPowEngine extends EventEmitter {
 
     const auxMerkleRoot = level[0];
 
+    poolLogger.emit('AUX_001', { chains: auxBlocks.length, merkleSize });
+
     return {
       auxMerkleRoot,
       auxMerkleSize: merkleSize,
@@ -329,6 +332,7 @@ class AuxPowEngine extends EventEmitter {
         }
       } catch (err) {
         log.warn({ coin: symbol, err: err.message }, 'AuxPoW lock acquire failed — proceeding without lock');
+        poolLogger.emit('AUX_004', { chain: symbol, error: err.message });
       }
     }
 
@@ -359,6 +363,7 @@ class AuxPowEngine extends EventEmitter {
           hash: auxBlock.hash,
           blocksFound: chain.blocksFound,
         }, `✅ ${symbol} aux block accepted!`);
+        poolLogger.emit('AUX_002', { chain: symbol, hash: auxBlock.hash, blocksFound: chain.blocksFound });
 
         this.emit('auxBlockFound', symbol, auxBlock, chain);
 
@@ -370,6 +375,7 @@ class AuxPowEngine extends EventEmitter {
           result,
           hash: auxBlock.hash,
         }, `❌ ${symbol} aux block rejected`);
+        poolLogger.emit('AUX_003', { chain: symbol, hash: auxBlock.hash, reason: result });
 
         this.emit('auxBlockRejected', symbol, auxBlock, result);
       }

--- a/src/blockchain/rpcClient.js
+++ b/src/blockchain/rpcClient.js
@@ -5,6 +5,7 @@
 
 const http = require('http');
 const { createLogger } = require('../utils/logger');
+const poolLogger = require('../logging/poolLogger');
 
 class RpcClient {
   /**
@@ -79,6 +80,9 @@ class RpcClient {
               const err = new Error(`RPC ${method}: ${parsed.error.message}`);
               err.code = parsed.error.code;
               this.log.error({ method, code: parsed.error.code }, `RPC error: ${parsed.error.message}`);
+              if (method === 'getblocktemplate') {
+                poolLogger.emit('DAEMON_008', { chain: this._chainLabel(), method, error: parsed.error.message });
+              }
               reject(err);
             } else {
               this._onSuccess();
@@ -94,6 +98,7 @@ class RpcClient {
       req.on('error', (err) => {
         this._onFailure();
         this.log.error({ method, err: err.message }, 'RPC connection error');
+        poolLogger.emit('DAEMON_003', { chain: this._chainLabel(), error: err.message });
         reject(err);
       });
 
@@ -101,6 +106,7 @@ class RpcClient {
         req.destroy();
         this._onFailure();
         this.log.error({ method }, 'RPC request timed out');
+        poolLogger.emit('DAEMON_002', { chain: this._chainLabel(), rpc: method });
         reject(new Error(`RPC ${method} timed out`));
       });
 
@@ -113,9 +119,15 @@ class RpcClient {
   // CIRCUIT BREAKER
   // ═══════════════════════════════════════════════════════
 
+  _chainLabel() {
+    return (this.coin || 'LTC').toUpperCase();
+  }
+
   _onSuccess() {
     if (this.circuitOpen) {
       this.log.info('RPC circuit closed — daemon recovered');
+      poolLogger.emit('DAEMON_007', { chain: this._chainLabel() });
+      poolLogger.emit('DAEMON_005', { chain: this._chainLabel() });
     }
     this.consecutiveFailures = 0;
     this.circuitOpen = false;
@@ -127,6 +139,7 @@ class RpcClient {
       this.circuitOpen = true;
       this.circuitOpenedAt = Date.now();
       this.log.error({ failures: this.consecutiveFailures }, 'RPC circuit OPEN — daemon unreachable');
+      poolLogger.emit('DAEMON_006', { chain: this._chainLabel(), failures: this.consecutiveFailures });
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const { STRATUM, OPS }      = require('./ux/copy');
 const RedisKeys             = require('./utils/redisKeys');
 
 // v0.7.0: New modules
-const MinerRegistry          = require('./pool/minerRegistry');
+const minerRegistry          = require('./pool/minerRegistry'); // v0.8.2: singleton instance
 const FirmwareTracker        = require('./pool/firmwareTracker');
 const HashrateOptimizer      = require('./pool/hashrateOptimizer');
 const IpReputation           = require('./pool/ipReputation');
@@ -59,6 +59,11 @@ const ConnectionFingerprint  = require('./pool/connectionFingerprint');
 const EmergencyLockdown      = require('./pool/emergencyLockdown');
 const AuditLog               = require('./pool/auditLog');
 const PoolWebSocketServer    = require('./api/websocket');
+
+// v0.8.2: Logging, metrics, and alert delivery
+const poolLogger             = require('./logging/poolLogger');
+const metricsExporter        = require('./logging/metricsExporter');
+const logDelivery            = require('./logging/logDelivery');
 
 const { version }           = require('../package.json');
 
@@ -98,6 +103,10 @@ async function main() {
   const db = initDatabase();
   await runMigrations();
   const dbQuery = { query };
+
+  // v0.8.2: Wire central pool logger with pg + metrics
+  poolLogger.setPg(db);
+  poolLogger.setMetrics(metricsExporter);
 
   log.info('Connecting to Redis...');
   const redis = new Redis({
@@ -139,6 +148,8 @@ async function main() {
     log.fatal('Cannot connect to Litecoin daemon — aborting');
     process.exit(1);
   }
+
+  poolLogger.emit('DAEMON_001', { chain: 'LTC' });
 
   const ltcInfo = await ltcRpc.getBlockchainInfo();
   log.info({ chain: ltcInfo.chain, blocks: ltcInfo.blocks, headers: ltcInfo.headers }, 'Litecoin daemon connected');
@@ -294,9 +305,9 @@ async function main() {
   log.info('🛡️  Nine-layer security engine ACTIVE');
 
   // ═══════════════════════════════════════════════════════
-  // v0.7.0: MINER MODEL DETECTION & FIRMWARE TRACKING
+  // v0.7.0/v0.8.2: MINER MODEL DETECTION & FIRMWARE TRACKING
+  // minerRegistry is now a module-level singleton (imported above).
   // ═══════════════════════════════════════════════════════
-  const minerRegistry = new MinerRegistry();
 
   const auditLog = new AuditLog({ db: dbQuery }, {
     retentionDays: parseInt(process.env.AUDIT_RETENTION_DAYS || '90'),
@@ -570,7 +581,7 @@ async function main() {
   const _walletCheckedMiners = new Set();
 
   shareProcessor.on('validShare', (client, share, auxProof) => {
-    prom.recordShare('valid');
+    metricsExporter.recordShare('valid');
     if (!client._isFleet) {
       banningManager.recordValidShare(client.remoteAddress);
       // L4 fingerprinting now handled by SecurityEngine.onShare()
@@ -615,7 +626,7 @@ async function main() {
   });
 
   shareProcessor.on('invalidShare', (client, share, reason) => {
-    prom.recordShare('rejected');
+    metricsExporter.recordShare('rejected');
     workerTracker.onInvalidShare(client);
     if (!client._isFleet) {
       banningManager.recordInvalidShare(client.remoteAddress);
@@ -627,7 +638,7 @@ async function main() {
   });
 
   shareProcessor.on('staleShare', (client) => {
-    prom.recordShare('stale');
+    metricsExporter.recordShare('stale');
     workerTracker.onStaleShare(client);
     if (!client._isFleet) {
       banningManager.recordInvalidShare(client.remoteAddress);
@@ -635,7 +646,7 @@ async function main() {
   });
 
   shareProcessor.on('duplicateShare', (client) => {
-    prom.recordShare('duplicate');
+    metricsExporter.recordShare('duplicate');
     if (!client._isFleet) {
       banningManager.recordViolation(client.remoteAddress, 'duplicate share');
     }
@@ -646,7 +657,7 @@ async function main() {
   // ═══════════════════════════════════════════════════════
 
   shareProcessor.on('blockFound', async (template, client) => {
-    prom.recordBlock('LTC', 'parent');
+    metricsExporter.recordBlock('LTC', 'parent');
     log.info({
       height: template.height,
       worker: client.workerName,
@@ -764,9 +775,15 @@ async function main() {
     connectionFingerprint,
   });
 
+  // v0.8.2: Prometheus /metrics endpoint
+  apiApp.get('/metrics', metricsExporter.metricsRoute);
+
   const httpServer = apiApp.listen(config.api.port, config.api.host, () => {
     log.info({ port: config.api.port }, '🌐 API server listening');
   });
+
+  // v0.8.2: WebSocket event stream at /ws/events
+  logDelivery.attach(httpServer);
 
   // v0.7.0: WebSocket server — attach to HTTP server
   const wsServer = new PoolWebSocketServer({
@@ -811,6 +828,9 @@ async function main() {
   // ─── Graceful Shutdown ──────────────────────────────────
   const shutdown = async (signal) => {
     log.info({ signal }, 'Shutting down LUXXPOOL...');
+    poolLogger.emit('SYS_002', { reason: signal });
+    // v0.8.2: Stop log delivery first so in-flight events don't hit a dying socket
+    try { logDelivery.stop(); } catch {}
     // v0.7.0: Stop new modules first
     wsServer.stop();
     hashrateOptimizer.stop();
@@ -868,8 +888,11 @@ async function main() {
   WebSocket:      🔌 /ws (pool, blocks, miner, admin)
   Miner Models:   🔧 ${minerRegistry.getAllModels().length} ASIC profiles loaded
   Redis:          ${redisConnected ? '✅' : '⚠️  degraded'}
+  Metrics:        📊 /metrics  │  Events:  🔌 /ws/events
   ═══════════════════════════════════════════════════════
   `);
+
+  poolLogger.emit('SYS_001', { version, auxChains: Object.keys(auxRpcClients) });
 }
 
 main().catch((err) => {

--- a/src/logging/alertDelivery.js
+++ b/src/logging/alertDelivery.js
@@ -1,0 +1,179 @@
+'use strict';
+
+/**
+ * LUXXPOOL v0.8.2 — Alert Delivery
+ *
+ * Out-of-band delivery of warn/error/critical events to the operator via:
+ *   - Email  (SMTP / nodemailer)
+ *   - Telegram Bot API (direct fetch)
+ *   - Generic webhook (direct fetch)
+ *
+ * Public API:
+ *   send(payload)  — await Promise<void> (never throws)
+ *
+ * Features:
+ *   - Per-(code,chain) cooldown (default 5 minutes, configurable via env)
+ *   - Channels enabled independently via ALERT_*_ENABLED env vars
+ *   - Env read at send-time so runtime changes take effect
+ *   - All failures caught and logged to stderr; delivery never throws
+ */
+
+const nodemailer = require('nodemailer');
+
+const cooldowns = new Map(); // key: `${code}:${chain}`, value: lastSentMs
+let cachedTransport = null;
+let cachedTransportKey = '';
+
+const SEVERITY_ICON = {
+  info: 'ℹ️',
+  warn: '⚠️',
+  error: '🚨',
+  critical: '🔴',
+};
+
+function _cooldownMs() {
+  const mins = parseInt(process.env.ALERT_COOLDOWN_MINUTES || '5', 10);
+  return (Number.isFinite(mins) && mins > 0 ? mins : 5) * 60_000;
+}
+
+function _formatTelegramText(payload) {
+  const icon = SEVERITY_ICON[payload.severity] || '•';
+  const time = new Date(payload.ts || Date.now()).toISOString().replace('T', ' ').slice(0, 19);
+  const details = payload.data ? JSON.stringify(payload.data, null, 0) : '';
+  return (
+    `${icon} LUXXPOOL [${payload.severity.toUpperCase()}]\n` +
+    `━━━━━━━━━━━━━━━\n` +
+    `Code: ${payload.event}\n` +
+    `Event: ${payload.name}\n` +
+    `Chain: ${payload.chain || 'LTC'}\n` +
+    `Time: ${time} UTC\n` +
+    (details && details !== '{}' ? `Details: ${details}\n` : '') +
+    `━━━━━━━━━━━━━━━`
+  );
+}
+
+function _formatEmailSubject(payload) {
+  return `[LUXXPOOL] ${payload.severity.toUpperCase()} — ${payload.name} [${payload.chain || 'LTC'}]`;
+}
+
+function _formatEmailBody(payload) {
+  const time = new Date(payload.ts || Date.now()).toISOString();
+  const header =
+    `Code:      ${payload.event}\n` +
+    `Event:     ${payload.name}\n` +
+    `Severity:  ${payload.severity}\n` +
+    `Chain:     ${payload.chain || 'LTC'}\n` +
+    `Category:  ${payload.category}\n` +
+    `Time:      ${time}\n\n`;
+  const details = `Details:\n${JSON.stringify(payload.data || {}, null, 2)}\n`;
+  return header + details;
+}
+
+async function _sendEmail(payload) {
+  const host = process.env.ALERT_SMTP_HOST;
+  const port = parseInt(process.env.ALERT_SMTP_PORT || '587', 10);
+  const user = process.env.ALERT_SMTP_USER;
+  const pass = process.env.ALERT_SMTP_PASS;
+  const from = process.env.ALERT_EMAIL_FROM || user;
+  const to = process.env.ALERT_EMAIL_TO;
+  if (!host || !user || !pass || !to) {
+    throw new Error('alert email missing required env (HOST/USER/PASS/TO)');
+  }
+
+  const key = `${host}:${port}:${user}`;
+  if (!cachedTransport || cachedTransportKey !== key) {
+    cachedTransport = nodemailer.createTransport({
+      host,
+      port,
+      secure: port === 465,
+      auth: { user, pass },
+    });
+    cachedTransportKey = key;
+  }
+
+  await cachedTransport.sendMail({
+    from,
+    to,
+    subject: _formatEmailSubject(payload),
+    text: _formatEmailBody(payload),
+  });
+}
+
+async function _sendTelegram(payload) {
+  const token = process.env.ALERT_TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.ALERT_TELEGRAM_CHAT_ID;
+  if (!token || !chatId) {
+    throw new Error('alert telegram missing TOKEN/CHAT_ID');
+  }
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  const body = { chat_id: chatId, text: _formatTelegramText(payload) };
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const msg = await res.text().catch(() => '');
+    throw new Error(`telegram HTTP ${res.status}: ${msg.slice(0, 200)}`);
+  }
+}
+
+async function _sendWebhook(payload) {
+  const url = process.env.ALERT_WEBHOOK_URL;
+  if (!url) throw new Error('alert webhook missing URL');
+  const secret = process.env.ALERT_WEBHOOK_SECRET || '';
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-LUXX-Secret': secret,
+      'X-LUXX-Event': payload.event,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`webhook HTTP ${res.status}`);
+  }
+}
+
+/**
+ * Dispatch an alert across all enabled channels.
+ * Never throws. Rejects silently on individual channel failure.
+ *
+ * @param {object} payload
+ * @param {string} payload.event    e.g. 'DAEMON_006'
+ * @param {string} payload.name     human-readable
+ * @param {string} payload.severity 'info' | 'warn' | 'error' | 'critical'
+ * @param {string} payload.category 'connection' | 'share' | ...
+ * @param {string} [payload.chain]  'LTC' | 'DOGE' | ...
+ * @param {number} [payload.ts]
+ * @param {object} [payload.data]
+ */
+async function send(payload) {
+  try {
+    if (!payload || payload.severity === 'info') return;
+
+    const key = `${payload.event}:${payload.chain || 'LTC'}`;
+    const last = cooldowns.get(key) || 0;
+    if (Date.now() - last < _cooldownMs()) return;
+    cooldowns.set(key, Date.now());
+
+    const jobs = [];
+    if (process.env.ALERT_EMAIL_ENABLED === 'true')    jobs.push(_sendEmail(payload));
+    if (process.env.ALERT_TELEGRAM_ENABLED === 'true') jobs.push(_sendTelegram(payload));
+    if (process.env.ALERT_WEBHOOK_ENABLED === 'true')  jobs.push(_sendWebhook(payload));
+
+    const results = await Promise.allSettled(jobs);
+    for (const r of results) {
+      if (r.status === 'rejected') {
+        process.stderr.write(`[alertDelivery] channel failed: ${r.reason?.message || r.reason}\n`);
+      }
+    }
+  } catch (err) {
+    process.stderr.write(`[alertDelivery] send error: ${err.message}\n`);
+  }
+}
+
+module.exports = { send, _cooldowns: cooldowns };

--- a/src/logging/eventCodes.js
+++ b/src/logging/eventCodes.js
@@ -1,0 +1,217 @@
+'use strict';
+
+/**
+ * LUXXPOOL v0.8.2 — Event Code Registry
+ *
+ * Every observable event in the pool is defined here. Codes are referenced
+ * throughout the codebase — do not rename. Order follows the v0.8.2 spec.
+ *
+ * Fields:
+ *   code        — unique string identifier (e.g. 'SHARE_001')
+ *   name        — human-readable short description
+ *   category    — connection | share | block | auxpow | daemon |
+ *                 vardiff | payment | security | system
+ *   severity    — info | warn | error | critical
+ *   persist     — true = insert into pool_events table; false = stdout only
+ *   metric      — Prometheus counter name (auto-registered)
+ *   description — one-sentence description for dashboards/docs
+ */
+
+const EVENTS = Object.freeze({
+  // ─── CONNECTION ──────────────────────────────────────────────────────────
+  CONN_001: { code: 'CONN_001', name: 'Miner connected', category: 'connection', severity: 'info',
+    persist: false, metric: 'pool_miner_connections_total',
+    description: 'A miner TCP socket connected to the stratum server.' },
+  CONN_002: { code: 'CONN_002', name: 'Miner disconnected (clean)', category: 'connection', severity: 'info',
+    persist: false, metric: 'pool_miner_disconnections_total',
+    description: 'A miner disconnected via clean socket close.' },
+  CONN_003: { code: 'CONN_003', name: 'Miner disconnected (timeout)', category: 'connection', severity: 'warn',
+    persist: false, metric: 'pool_miner_timeouts_total',
+    description: 'A miner was disconnected due to socket idle timeout.' },
+  CONN_004: { code: 'CONN_004', name: 'Stratum handshake failed', category: 'connection', severity: 'warn',
+    persist: true, metric: 'pool_handshake_failures_total',
+    description: 'Stratum subscribe handshake could not be completed.' },
+  CONN_005: { code: 'CONN_005', name: 'Worker authorized', category: 'connection', severity: 'info',
+    persist: false, metric: 'pool_workers_authorized_total',
+    description: 'A worker successfully authorized with mining.authorize.' },
+  CONN_006: { code: 'CONN_006', name: 'Worker auth failed', category: 'connection', severity: 'warn',
+    persist: true, metric: 'pool_auth_failures_total',
+    description: 'A mining.authorize attempt failed (invalid address or credentials).' },
+
+  // ─── SHARE ───────────────────────────────────────────────────────────────
+  SHARE_001: { code: 'SHARE_001', name: 'Share accepted', category: 'share', severity: 'info',
+    persist: false, metric: 'pool_shares_accepted_total',
+    description: 'A submitted share met target difficulty and was accepted.' },
+  SHARE_002: { code: 'SHARE_002', name: 'Share rejected — stale', category: 'share', severity: 'warn',
+    persist: false, metric: 'pool_shares_stale_total',
+    description: 'Share was rejected because its job is no longer current.' },
+  SHARE_003: { code: 'SHARE_003', name: 'Share rejected — low diff', category: 'share', severity: 'warn',
+    persist: false, metric: 'pool_shares_low_diff_total',
+    description: 'Share was rejected for failing to meet required difficulty.' },
+  SHARE_004: { code: 'SHARE_004', name: 'Share rejected — duplicate', category: 'share', severity: 'warn',
+    persist: true, metric: 'pool_shares_duplicate_total',
+    description: 'A duplicate share (same nonce) was submitted.' },
+  SHARE_005: { code: 'SHARE_005', name: 'Share rejected — invalid', category: 'share', severity: 'error',
+    persist: true, metric: 'pool_shares_invalid_total',
+    description: 'Share failed hash verification or had malformed fields.' },
+  SHARE_006: { code: 'SHARE_006', name: 'Share flood detected', category: 'share', severity: 'warn',
+    persist: true, metric: 'pool_share_flood_events_total',
+    description: 'A client exceeded the per-minute share submission limit.' },
+
+  // ─── BLOCK ───────────────────────────────────────────────────────────────
+  BLOCK_001: { code: 'BLOCK_001', name: 'Block candidate submitted', category: 'block', severity: 'info',
+    persist: true, metric: 'pool_blocks_submitted_total',
+    description: 'A candidate block was submitted to the daemon via submitblock.' },
+  BLOCK_002: { code: 'BLOCK_002', name: 'Block accepted by network', category: 'block', severity: 'info',
+    persist: true, metric: 'pool_blocks_found_total',
+    description: 'Submitted block was accepted by the network.' },
+  BLOCK_003: { code: 'BLOCK_003', name: 'Block rejected by network', category: 'block', severity: 'error',
+    persist: true, metric: 'pool_blocks_rejected_total',
+    description: 'Submitted block was rejected by the daemon.' },
+  BLOCK_004: { code: 'BLOCK_004', name: 'Block orphaned', category: 'block', severity: 'error',
+    persist: true, metric: 'pool_blocks_orphaned_total',
+    description: 'A previously accepted block was orphaned after confirmation checks.' },
+  BLOCK_005: { code: 'BLOCK_005', name: 'New job broadcast', category: 'block', severity: 'info',
+    persist: false, metric: 'pool_jobs_broadcast_total',
+    description: 'A new mining job was broadcast to connected miners.' },
+  BLOCK_006: { code: 'BLOCK_006', name: 'Job stale (superseded)', category: 'block', severity: 'info',
+    persist: false, metric: 'pool_jobs_stale_total',
+    description: 'A previous job was superseded by a newer template.' },
+
+  // ─── AUXPOW ──────────────────────────────────────────────────────────────
+  AUX_001: { code: 'AUX_001', name: 'AuxPoW merkle computed', category: 'auxpow', severity: 'info',
+    persist: false, metric: 'pool_auxpow_merkle_computed_total',
+    description: 'AuxPoW merkle tree rebuilt for the current job.' },
+  AUX_002: { code: 'AUX_002', name: 'Aux chain block accepted', category: 'auxpow', severity: 'info',
+    persist: true, metric: 'pool_aux_blocks_found_total',
+    description: 'An auxiliary chain block was accepted by its network.' },
+  AUX_003: { code: 'AUX_003', name: 'Aux chain block rejected', category: 'auxpow', severity: 'warn',
+    persist: true, metric: 'pool_aux_blocks_rejected_total',
+    description: 'An auxiliary chain block submission was rejected.' },
+  AUX_004: { code: 'AUX_004', name: 'Aux merkle lock failed', category: 'auxpow', severity: 'error',
+    persist: true, metric: 'pool_auxpow_lock_failures_total',
+    description: 'Failed to acquire the distributed lock for aux submission.' },
+
+  // ─── DAEMON ──────────────────────────────────────────────────────────────
+  DAEMON_001: { code: 'DAEMON_001', name: 'Daemon connected', category: 'daemon', severity: 'info',
+    persist: true, metric: 'pool_daemon_connections_total',
+    description: 'RPC connection to a coin daemon established.' },
+  DAEMON_002: { code: 'DAEMON_002', name: 'Daemon RPC timeout', category: 'daemon', severity: 'warn',
+    persist: true, metric: 'pool_daemon_timeouts_total',
+    description: 'An RPC call to a daemon exceeded its timeout.' },
+  DAEMON_003: { code: 'DAEMON_003', name: 'Daemon connection lost', category: 'daemon', severity: 'error',
+    persist: true, metric: 'pool_daemon_disconnections_total',
+    description: 'Daemon RPC connection failed (socket error).' },
+  DAEMON_004: { code: 'DAEMON_004', name: 'Daemon sync stalled', category: 'daemon', severity: 'warn',
+    persist: true, metric: 'pool_daemon_stalls_total',
+    description: 'Daemon height has not advanced within the expected window.' },
+  DAEMON_005: { code: 'DAEMON_005', name: 'Daemon recovered', category: 'daemon', severity: 'info',
+    persist: true, metric: 'pool_daemon_recoveries_total',
+    description: 'Daemon RPC calls are succeeding again after a failure period.' },
+  DAEMON_006: { code: 'DAEMON_006', name: 'Circuit breaker OPEN', category: 'daemon', severity: 'error',
+    persist: true, metric: 'pool_circuit_breaker_open_total',
+    description: 'Circuit breaker tripped to OPEN due to repeated RPC failures.' },
+  DAEMON_007: { code: 'DAEMON_007', name: 'Circuit breaker CLOSED', category: 'daemon', severity: 'info',
+    persist: true, metric: 'pool_circuit_breaker_close_total',
+    description: 'Circuit breaker returned to CLOSED after successful probes.' },
+  DAEMON_008: { code: 'DAEMON_008', name: 'getblocktemplate error', category: 'daemon', severity: 'error',
+    persist: true, metric: 'pool_gbt_errors_total',
+    description: 'getblocktemplate RPC returned an error.' },
+
+  // ─── VARDIFF ─────────────────────────────────────────────────────────────
+  VARDIFF_001: { code: 'VARDIFF_001', name: 'Difficulty adjusted UP', category: 'vardiff', severity: 'info',
+    persist: false, metric: 'pool_vardiff_adjustments_up_total',
+    description: 'VarDiff retargeted a miner to a higher difficulty.' },
+  VARDIFF_002: { code: 'VARDIFF_002', name: 'Difficulty adjusted DOWN', category: 'vardiff', severity: 'info',
+    persist: false, metric: 'pool_vardiff_adjustments_down_total',
+    description: 'VarDiff retargeted a miner to a lower difficulty.' },
+  VARDIFF_003: { code: 'VARDIFF_003', name: 'Hashrate estimated', category: 'vardiff', severity: 'info',
+    persist: false, metric: 'pool_hashrate_estimates_total',
+    description: 'A hashrate estimate was computed for a worker.' },
+  VARDIFF_004: { code: 'VARDIFF_004', name: 'Vardiff at ceiling', category: 'vardiff', severity: 'warn',
+    persist: false, metric: 'pool_vardiff_ceiling_hits_total',
+    description: 'A miner has reached the configured vardiff ceiling.' },
+
+  // ─── PAYMENT ─────────────────────────────────────────────────────────────
+  PAY_001: { code: 'PAY_001', name: 'PPLNS window recalculated', category: 'payment', severity: 'info',
+    persist: true, metric: 'pool_pplns_recalculations_total',
+    description: 'The PPLNS share window was recomputed for a confirmed block.' },
+  PAY_002: { code: 'PAY_002', name: 'Payment batch initiated', category: 'payment', severity: 'info',
+    persist: true, metric: 'pool_payment_batches_total',
+    description: 'A payment batch has started processing.' },
+  PAY_003: { code: 'PAY_003', name: 'LTC payment sent', category: 'payment', severity: 'info',
+    persist: true, metric: 'pool_payments_sent_total',
+    description: 'A Litecoin payment transaction was broadcast successfully.' },
+  PAY_004: { code: 'PAY_004', name: 'Aux payment sent', category: 'payment', severity: 'info',
+    persist: true, metric: 'pool_aux_payments_sent_total',
+    description: 'An auxiliary-chain payment transaction was broadcast successfully.' },
+  PAY_005: { code: 'PAY_005', name: 'Payment failed', category: 'payment', severity: 'error',
+    persist: true, metric: 'pool_payment_failures_total',
+    description: 'A payment batch failed and will be retried.' },
+  PAY_006: { code: 'PAY_006', name: 'Below payout threshold', category: 'payment', severity: 'info',
+    persist: false, metric: 'pool_payout_skipped_threshold_total',
+    description: 'A miner payout was skipped because it is below the threshold.' },
+
+  // ─── SECURITY ────────────────────────────────────────────────────────────
+  SEC_001: { code: 'SEC_001', name: 'Rate limit triggered', category: 'security', severity: 'warn',
+    persist: true, metric: 'pool_rate_limit_hits_total',
+    description: 'Rate-limit layer rejected or throttled a miner.' },
+  SEC_002: { code: 'SEC_002', name: 'IP banned (auto)', category: 'security', severity: 'warn',
+    persist: true, metric: 'pool_bans_total',
+    description: 'A miner IP was auto-banned by the security engine.' },
+  SEC_003: { code: 'SEC_003', name: 'Sybil detection triggered', category: 'security', severity: 'warn',
+    persist: true, metric: 'pool_sybil_events_total',
+    description: 'Sybil pattern (multiple addresses sharing an IP) was detected.' },
+  SEC_004: { code: 'SEC_004', name: 'Suspicious share pattern', category: 'security', severity: 'error',
+    persist: true, metric: 'pool_suspicious_share_events_total',
+    description: 'Share fingerprint layer flagged a suspicious pattern (BWH/stale abuse).' },
+  SEC_005: { code: 'SEC_005', name: 'Invalid miner address', category: 'security', severity: 'warn',
+    persist: true, metric: 'pool_invalid_address_total',
+    description: 'A worker attempted to authorize with an invalid payout address.' },
+  SEC_006: { code: 'SEC_006', name: 'API abuse detected', category: 'security', severity: 'warn',
+    persist: true, metric: 'pool_api_abuse_total',
+    description: 'API rate-limit or abuse handler fired.' },
+
+  // ─── SYSTEM ──────────────────────────────────────────────────────────────
+  SYS_001: { code: 'SYS_001', name: 'Pool startup', category: 'system', severity: 'info',
+    persist: true, metric: 'pool_startups_total',
+    description: 'Pool finished initialization and is accepting miners.' },
+  SYS_002: { code: 'SYS_002', name: 'Pool shutdown (clean)', category: 'system', severity: 'info',
+    persist: true, metric: 'pool_shutdowns_total',
+    description: 'Pool is shutting down cleanly.' },
+  SYS_003: { code: 'SYS_003', name: 'PostgreSQL error', category: 'system', severity: 'error',
+    persist: false, metric: 'pool_pg_errors_total',
+    description: 'A PostgreSQL query or pool error occurred.' },
+  SYS_004: { code: 'SYS_004', name: 'Redis error', category: 'system', severity: 'error',
+    persist: true, metric: 'pool_redis_errors_total',
+    description: 'Redis connection or command failed.' },
+  SYS_005: { code: 'SYS_005', name: 'Redis reconnected', category: 'system', severity: 'info',
+    persist: true, metric: 'pool_redis_reconnections_total',
+    description: 'Redis connection was restored after a failure.' },
+  SYS_006: { code: 'SYS_006', name: 'High memory usage', category: 'system', severity: 'warn',
+    persist: true, metric: 'pool_memory_warnings_total',
+    description: 'Process RSS exceeded the configured warning threshold.' },
+  SYS_007: { code: 'SYS_007', name: 'Disk space warning', category: 'system', severity: 'warn',
+    persist: true, metric: 'pool_disk_warnings_total',
+    description: 'Free disk space fell below the configured threshold.' },
+  SYS_008: { code: 'SYS_008', name: 'API 500 error', category: 'system', severity: 'error',
+    persist: true, metric: 'pool_api_500_errors_total',
+    description: 'An unhandled error was thrown by an API route.' },
+  SYS_009: { code: 'SYS_009', name: 'Prometheus metrics scraped', category: 'system', severity: 'info',
+    persist: false, metric: 'pool_prometheus_scrapes_total',
+    description: 'The /metrics endpoint was scraped.' },
+});
+
+function getEvent(code) {
+  return EVENTS[code];
+}
+
+function getByCategory(category) {
+  return Object.values(EVENTS).filter(ev => ev.category === category);
+}
+
+function getBySeverity(severity) {
+  return Object.values(EVENTS).filter(ev => ev.severity === severity);
+}
+
+module.exports = { EVENTS, getEvent, getByCategory, getBySeverity };

--- a/src/logging/logDelivery.js
+++ b/src/logging/logDelivery.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/**
+ * LUXXPOOL v0.8.2 — Log Delivery (WebSocket)
+ *
+ * Streams pool_events in real time to dashboard/monitoring clients over
+ * WebSocket at /ws/events. This is intentionally separate from the existing
+ * PoolWebSocketServer (which handles dashboard data channels and auth) so
+ * log floods cannot impact the dashboard path.
+ *
+ * Public API:
+ *   attach(httpServer)  — mounts a WS.Server on path /ws/events
+ *   stop()              — closes the server and all clients
+ *
+ * Client protocol:
+ *   On connect, server sends { type: 'registry', events: [...] }
+ *   Heartbeat every 10s:   { type: 'heartbeat', ts, clients }
+ *   Each event:            { type: 'event', payload }
+ *
+ * Client-to-server control messages:
+ *   { subscribe: ['share', 'block', ...] }   — filter by category
+ *   { minSeverity: 'warn' }                   — filter by severity threshold
+ */
+
+const WebSocket = require('ws');
+const { EVENTS } = require('./eventCodes');
+const poolLogger = require('./poolLogger');
+
+const SEVERITY_ORDER = { info: 0, warn: 1, error: 2, critical: 3 };
+
+let wss = null;
+let heartbeatTimer = null;
+
+function _passesFilter(client, payload) {
+  if (client._subscribe && client._subscribe.size && !client._subscribe.has(payload.category)) {
+    return false;
+  }
+  if (client._minSeverity != null) {
+    const sev = SEVERITY_ORDER[payload.severity] ?? 0;
+    if (sev < client._minSeverity) return false;
+  }
+  return true;
+}
+
+function _send(ws, obj) {
+  if (ws.readyState !== WebSocket.OPEN) return;
+  try { ws.send(JSON.stringify(obj)); } catch (_) { /* swallow */ }
+}
+
+function _broadcast(payload) {
+  if (!wss) return;
+  for (const ws of wss.clients) {
+    if (ws.readyState !== WebSocket.OPEN) continue;
+    if (!_passesFilter(ws, payload)) continue;
+    _send(ws, { type: 'event', payload });
+  }
+}
+
+function _handleConnection(ws) {
+  ws._subscribe = null;
+  ws._minSeverity = null;
+
+  _send(ws, { type: 'registry', events: Object.values(EVENTS) });
+
+  ws.on('message', (raw) => {
+    let msg;
+    try { msg = JSON.parse(raw.toString()); } catch { return; }
+    if (Array.isArray(msg.subscribe)) {
+      ws._subscribe = new Set(msg.subscribe);
+    }
+    if (typeof msg.minSeverity === 'string' && msg.minSeverity in SEVERITY_ORDER) {
+      ws._minSeverity = SEVERITY_ORDER[msg.minSeverity];
+    }
+  });
+
+  ws.on('error', () => { try { ws.terminate(); } catch (_) {} });
+  ws.on('close', () => { /* ws.Server removes from wss.clients automatically */ });
+}
+
+function attach(httpServer) {
+  if (wss) return;
+
+  wss = new WebSocket.Server({ server: httpServer, path: '/ws/events' });
+  wss.on('connection', _handleConnection);
+
+  poolLogger.bus.on('pool_event', _broadcast);
+
+  heartbeatTimer = setInterval(() => {
+    if (!wss) return;
+    const msg = { type: 'heartbeat', ts: Date.now(), clients: wss.clients.size };
+    for (const ws of wss.clients) _send(ws, msg);
+  }, 10_000);
+  if (heartbeatTimer.unref) heartbeatTimer.unref();
+}
+
+function stop() {
+  if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
+  if (wss) {
+    for (const ws of wss.clients) {
+      try { ws.terminate(); } catch (_) {}
+    }
+    wss.close();
+    wss = null;
+  }
+  poolLogger.bus.removeListener('pool_event', _broadcast);
+}
+
+module.exports = { attach, stop };

--- a/src/logging/metricsExporter.js
+++ b/src/logging/metricsExporter.js
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * LUXXPOOL v0.8.2 — Prometheus Metrics Exporter
+ *
+ * Auto-registers one Counter per unique event metric name from eventCodes.js,
+ * plus gauges for current pool state and histograms for latency distributions.
+ *
+ * Public API:
+ *   increment(metricName, labels)   — bump a counter
+ *   setGauge(name, value, labels)
+ *   observe(name, value, labels)
+ *   metricsRoute(req, res)          — Express handler for GET /metrics
+ *   recordShare(status)             — back-compat shim for src/index.js
+ *   recordBlock(chain, kind)        — back-compat shim for src/index.js
+ *   register                         — underlying prom-client Registry
+ *   gauges, histograms              — direct access to registered objects
+ */
+
+const client = require('prom-client');
+const { EVENTS } = require('./eventCodes');
+
+const register = new client.Registry();
+
+// Default Node.js metrics (CPU, memory, GC, event-loop lag, etc.)
+client.collectDefaultMetrics({ register, prefix: 'pool_node_' });
+
+// ─── Counters — one per unique event metric ────────────────────────────────
+const counters = new Map();
+for (const ev of Object.values(EVENTS)) {
+  if (counters.has(ev.metric)) continue;
+  const counter = new client.Counter({
+    name: ev.metric,
+    help: ev.description || ev.name,
+    labelNames: ['category', 'severity', 'chain'],
+    registers: [register],
+  });
+  counters.set(ev.metric, counter);
+}
+
+// ─── Gauges ────────────────────────────────────────────────────────────────
+const gauges = {
+  connectedMiners: new client.Gauge({
+    name: 'pool_connected_miners', help: 'Currently connected miners',
+    labelNames: ['chain'], registers: [register] }),
+  hashrateMhs: new client.Gauge({
+    name: 'pool_hashrate_mhs', help: 'Pool hashrate in MH/s',
+    labelNames: ['chain'], registers: [register] }),
+  networkDifficultyLtc: new client.Gauge({
+    name: 'pool_network_difficulty_ltc', help: 'Current LTC network difficulty',
+    registers: [register] }),
+  pendingPayoutLtc: new client.Gauge({
+    name: 'pool_pending_payout_ltc', help: 'Pending LTC payouts across all miners',
+    registers: [register] }),
+  daemonBlockHeight: new client.Gauge({
+    name: 'pool_daemon_block_height', help: 'Current daemon block height',
+    labelNames: ['chain'], registers: [register] }),
+  daemonSynced: new client.Gauge({
+    name: 'pool_daemon_synced', help: 'Daemon sync state (1=synced, 0=syncing)',
+    labelNames: ['chain'], registers: [register] }),
+  circuitBreakerState: new client.Gauge({
+    name: 'pool_circuit_breaker_state', help: 'Circuit breaker state (0=closed, 1=half-open, 2=open)',
+    labelNames: ['chain'], registers: [register] }),
+  shareAcceptRate: new client.Gauge({
+    name: 'pool_share_accept_rate', help: 'Rolling share accept rate (0.0–1.0)',
+    registers: [register] }),
+  pplnsWindowShares: new client.Gauge({
+    name: 'pool_pplns_window_shares', help: 'Total shares in current PPLNS window',
+    registers: [register] }),
+  lastBlockFoundTimestamp: new client.Gauge({
+    name: 'pool_last_block_found_timestamp', help: 'Unix timestamp of last block found',
+    labelNames: ['chain'], registers: [register] }),
+};
+
+// ─── Histograms ────────────────────────────────────────────────────────────
+const histograms = {
+  shareValidationDurationMs: new client.Histogram({
+    name: 'pool_share_validation_duration_ms', help: 'Share validation latency',
+    buckets: [0.5, 1, 2, 5, 10, 25, 50], registers: [register] }),
+  rpcLatencyMs: new client.Histogram({
+    name: 'pool_rpc_latency_ms', help: 'RPC call latency',
+    labelNames: ['chain', 'method'],
+    buckets: [5, 10, 25, 50, 100, 250, 500, 1000], registers: [register] }),
+  paymentBatchDurationMs: new client.Histogram({
+    name: 'pool_payment_batch_duration_ms', help: 'Payment batch execution duration',
+    buckets: [100, 250, 500, 1000, 2500, 5000], registers: [register] }),
+};
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+function increment(metricName, labels = {}) {
+  const c = counters.get(metricName);
+  if (!c) return;
+  const safeLabels = {
+    category: labels.category || 'unknown',
+    severity: labels.severity || 'info',
+    chain: labels.chain || 'LTC',
+  };
+  c.inc(safeLabels);
+}
+
+function setGauge(name, value, labels = {}) {
+  const g = gauges[name];
+  if (!g) return;
+  if (Object.keys(labels).length) g.set(labels, value);
+  else g.set(value);
+}
+
+function observe(name, value, labels = {}) {
+  const h = histograms[name];
+  if (!h) return;
+  if (Object.keys(labels).length) h.observe(labels, value);
+  else h.observe(value);
+}
+
+// Back-compat shim for existing calls in src/index.js (lines 573, 618, 630, 638, 649).
+// Maps legacy `prom.recordShare(status)` / `prom.recordBlock(chain, kind)` to the
+// new per-event counters.
+const SHARE_STATUS_METRIC = {
+  valid:     'pool_shares_accepted_total',
+  rejected:  'pool_shares_invalid_total',
+  stale:     'pool_shares_stale_total',
+  duplicate: 'pool_shares_duplicate_total',
+  lowdiff:   'pool_shares_low_diff_total',
+};
+
+function recordShare(status, chain = 'LTC') {
+  const metric = SHARE_STATUS_METRIC[status];
+  if (!metric) return;
+  increment(metric, { category: 'share', severity: status === 'valid' ? 'info' : 'warn', chain });
+}
+
+function recordBlock(chain = 'LTC', _kind = 'parent') {
+  increment('pool_blocks_found_total', { category: 'block', severity: 'info', chain });
+}
+
+async function metricsRoute(_req, res) {
+  try {
+    increment('pool_prometheus_scrapes_total', { category: 'system', severity: 'info', chain: 'LTC' });
+    res.set('Content-Type', register.contentType);
+    res.end(await register.metrics());
+  } catch (err) {
+    res.status(500).end(err.message);
+  }
+}
+
+module.exports = {
+  increment,
+  setGauge,
+  observe,
+  metricsRoute,
+  recordShare,
+  recordBlock,
+  register,
+  gauges,
+  histograms,
+  counters,
+};

--- a/src/logging/poolLogger.js
+++ b/src/logging/poolLogger.js
@@ -1,0 +1,180 @@
+'use strict';
+
+/**
+ * LUXXPOOL v0.8.2 — Pool Logger
+ *
+ * The single entry point for every observable event in the pool.
+ * One call to logger.emit(code, data) fans out to:
+ *   1. Pino structured stdout (always, severity-mapped)
+ *   2. PostgreSQL pool_events table (if event.persist && pg wired)
+ *   3. Prometheus counter (if metrics wired)
+ *   4. Alert delivery — email/telegram/webhook (warn/error/critical only)
+ *   5. Internal EventEmitter bus (for WebSocket + internal consumers)
+ *
+ * All side effects are non-blocking and non-throwing. A failure in any
+ * delivery channel is logged to stdout but never propagates to the caller.
+ *
+ * Exports a singleton. `index.js` wires pg + metrics once at startup.
+ */
+
+const EventEmitter = require('events');
+const { createLogger } = require('../utils/logger');
+const { EVENTS, getEvent } = require('./eventCodes');
+const alertDelivery = require('./alertDelivery');
+
+class PoolLogger {
+  constructor() {
+    this.log = createLogger('pool');
+    this.bus = new EventEmitter();
+    this.bus.setMaxListeners(50);
+    this._pg = null;
+    this._metrics = null;
+  }
+
+  /** Called once from src/index.js after the pg Pool is initialized. */
+  setPg(pgPool) { this._pg = pgPool; }
+
+  /** Called once from src/index.js after metricsExporter is required. */
+  setMetrics(exporter) { this._metrics = exporter; }
+
+  /**
+   * Emit an event.
+   * @param {string} code   — event code from eventCodes.js (e.g. 'SHARE_001')
+   * @param {object} [data] — event metadata (address, worker, chain, etc.)
+   */
+  emit(code, data = {}) {
+    const ev = getEvent(code);
+    if (!ev) {
+      this.log.warn({ code }, 'poolLogger: unknown event code');
+      return;
+    }
+
+    const payload = {
+      ts: Date.now(),
+      event: code,
+      name: ev.name,
+      category: ev.category,
+      severity: ev.severity,
+      chain: data.chain || 'LTC',
+      data,
+    };
+
+    // 1. Pino stdout — always
+    const pinoLevel = ev.severity === 'critical' ? 'error' : ev.severity;
+    try {
+      this.log[pinoLevel]({ ev: code, chain: payload.chain, ...data }, ev.name);
+    } catch (_) { /* never throw */ }
+
+    // 2. Prometheus counter — always (if wired)
+    if (this._metrics) {
+      try {
+        this._metrics.increment(ev.metric, {
+          category: ev.category,
+          severity: ev.severity,
+          chain: payload.chain,
+        });
+      } catch (err) {
+        this.log.warn({ err: err.message, code }, 'metrics increment failed');
+      }
+    }
+
+    // 3. PostgreSQL persistence — only if persist && pg wired (fire and forget)
+    if (ev.persist && this._pg) {
+      this._persistToDb(payload).catch(err => {
+        this.log.error({ err: err.message, code }, 'pool_events insert failed');
+      });
+    }
+
+    // 4. Alert delivery — warn/error/critical only (fire and forget)
+    if (ev.severity !== 'info') {
+      alertDelivery.send(payload).catch(() => { /* never throw */ });
+    }
+
+    // 5. WebSocket bus — always
+    try {
+      this.bus.emit('pool_event', payload);
+      this.bus.emit(ev.category, payload);
+    } catch (_) { /* never throw */ }
+  }
+
+  async _persistToDb(p) {
+    const d = p.data || {};
+    await this._pg.query(
+      `INSERT INTO pool_events
+         (code, category, severity, chain, address, worker, diff,
+          block_height, txid, error_msg, meta)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+      [
+        p.event,
+        p.category,
+        p.severity,
+        p.chain,
+        d.address || null,
+        d.worker || null,
+        d.diff || d.difficulty || null,
+        d.height || d.block_height || null,
+        d.txid || null,
+        d.error || d.reason || null,
+        JSON.stringify(d),
+      ]
+    );
+  }
+
+  // ─── Convenience wrappers (thin — all call emit) ─────────────────────────
+
+  get share() {
+    return {
+      accepted: (address, worker, diff, jobId) =>
+        this.emit('SHARE_001', { address, worker, diff, jobId }),
+      stale: (address, worker, jobId) =>
+        this.emit('SHARE_002', { address, worker, jobId }),
+      lowDiff: (address, worker, submittedDiff, requiredDiff) =>
+        this.emit('SHARE_003', { address, worker, submittedDiff, requiredDiff }),
+      duplicate: (address, worker, nonce) =>
+        this.emit('SHARE_004', { address, worker, nonce }),
+      invalid: (address, worker, reason) =>
+        this.emit('SHARE_005', { address, worker, reason }),
+    };
+  }
+
+  get block() {
+    return {
+      submitted: (height, hash, chain = 'LTC') =>
+        this.emit('BLOCK_001', { height, hash, chain }),
+      accepted: (height, hash, reward, chain = 'LTC') =>
+        this.emit('BLOCK_002', { height, hash, reward, chain }),
+      rejected: (height, hash, reason, chain = 'LTC') =>
+        this.emit('BLOCK_003', { height, hash, reason, chain }),
+      orphaned: (height, hash, chain = 'LTC') =>
+        this.emit('BLOCK_004', { height, hash, chain }),
+    };
+  }
+
+  get daemon() {
+    return {
+      connected: (chain) => this.emit('DAEMON_001', { chain }),
+      timeout: (chain, rpc) => this.emit('DAEMON_002', { chain, rpc }),
+      lost: (chain, error) => this.emit('DAEMON_003', { chain, error: error?.message || error }),
+      stalled: (chain, lastHeight, stalledFor) =>
+        this.emit('DAEMON_004', { chain, lastHeight, stalledFor }),
+      recovered: (chain) => this.emit('DAEMON_005', { chain }),
+      circuitOpen: (chain, failures) => this.emit('DAEMON_006', { chain, failures }),
+      circuitClosed: (chain) => this.emit('DAEMON_007', { chain }),
+    };
+  }
+
+  get system() {
+    return {
+      startup: (meta = {}) => this.emit('SYS_001', meta),
+      shutdown: (reason) => this.emit('SYS_002', { reason }),
+      pgError: (error) => this.emit('SYS_003', { error: error?.message || error }),
+      redisError: (error) => this.emit('SYS_004', { error: error?.message || error }),
+      redisReconnected: () => this.emit('SYS_005', {}),
+      highMemory: (usedMb, totalMb) => this.emit('SYS_006', { usedMb, totalMb }),
+      diskWarning: (path, usedPct) => this.emit('SYS_007', { path, usedPct }),
+      api500: (route, error) => this.emit('SYS_008', { route, error: error?.message || error }),
+    };
+  }
+}
+
+module.exports = new PoolLogger();

--- a/src/payment/paymentProcessor.js
+++ b/src/payment/paymentProcessor.js
@@ -5,6 +5,7 @@
 
 const EventEmitter = require('events');
 const { createLogger } = require('../utils/logger');
+const poolLogger = require('../logging/poolLogger');
 
 const log = createLogger('payments');
 
@@ -188,6 +189,12 @@ class PaymentProcessor extends EventEmitter {
         shares[row.address] = parseFloat(row.total_diff);
       }
 
+      poolLogger.emit('PAY_001', {
+        block_height: block.height,
+        miners: Object.keys(shares).length,
+        window: windowBlocks,
+      });
+
       return shares;
     } catch (err) {
       log.error({ err: err.message }, 'PPLNS calculation failed');
@@ -265,6 +272,11 @@ class PaymentProcessor extends EventEmitter {
           batchSize: batchAddresses.length,
           totalAmount: Object.values(batch).reduce((a, b) => a + b, 0),
         }, 'Sending batch payment');
+        poolLogger.emit('PAY_002', {
+          batchSize: batchAddresses.length,
+          block_height: block.height,
+          totalAmount: Object.values(batch).reduce((a, b) => a + b, 0),
+        });
 
         // Record pending payments BEFORE sending (idempotency guard)
         const pendingIds = [];
@@ -280,6 +292,12 @@ class PaymentProcessor extends EventEmitter {
         const txid = await this.rpc.sendMany('', batch);
 
         log.info({ txid, batchSize: batchAddresses.length }, 'Batch payment sent');
+        poolLogger.emit('PAY_003', {
+          txid,
+          batchSize: batchAddresses.length,
+          amount: Object.values(batch).reduce((a, b) => a + b, 0),
+          block_height: block.height,
+        });
 
         // Mark pending payments as sent with txid
         for (const id of pendingIds) {
@@ -314,6 +332,7 @@ class PaymentProcessor extends EventEmitter {
 
     } catch (err) {
       log.error({ err: err.message }, 'Batch payment execution failed');
+      poolLogger.emit('PAY_005', { block_height: block.height, error: err.message });
 
       // Record failed payments
       for (const [address, amount] of Object.entries(payments)) {

--- a/src/pool/minerRegistry.js
+++ b/src/pool/minerRegistry.js
@@ -1,67 +1,205 @@
+'use strict';
+
 /**
- * LUXXPOOL v0.7.0 — Miner Registry
+ * LUXXPOOL v0.8.2 — Miner Registry
  * ═══════════════════════════════════════════════════════════
  * Identifies Scrypt ASIC models from Stratum user-agent strings.
  * Provides model-aware optimal difficulty, expected hashrate,
  * and known firmware version data for each supported model.
  *
- * Supported Models:
- *   Antminer L9  (340 GH/s) — Bitmain flagship Scrypt ASIC
- *   Antminer L7  (9.5 GH/s) — Previous generation
- *   Antminer L3+ (504 MH/s) — Legacy, still widely deployed
- *   ElphaPex DG2 (36 GH/s)  — Newer competitor
- *   ElphaPex DG1 (14 GH/s)  — Entry-level ElphaPex
- *   VOLCMINER D1 (5 GH/s)   — Budget ASIC
- *   Goldshell LT6 (3.35 GH/s) — Goldshell flagship
- *   Goldshell LT5 Pro (2.45 GH/s) — Mid-range Goldshell
+ * v0.8.2 EXPANSION: 8 profiles → 20 profiles
+ * Added: L7 Pro, L11, L11 Pro, L11 Hydro, U2L9H,
+ *        DG1+, DG2+, DG Hydro 1, DG Home 1,
+ *        VolcMiner D1 Hydro, D3,
+ *        Goldshell LT Lite, LT5, E-DG1M,
+ *        Bitdeer Sealminer DL1, Fluminer L1
  *
- * Security Context:
- *   - ASIC firmware compromise is a high-probability threat
- *   - L9 runs Angstrom Linux with known vulnerabilities:
- *     unsigned firmware upgrades, default SSH (root/root), CGI as root
- *   - User-agent can be spoofed; use as advisory, not for security decisions
+ * HOW DETECTION WORKS:
+ *   The Stratum mining.subscribe message includes a user-agent string
+ *   as the second parameter. Format varies by manufacturer firmware:
+ *     Bitmain:   "cgminer/4.11.1" or "bmminer/2.0.0 Antminer L9"
+ *     ElphaPex:  "ElphaPex DG1+ v2.1.0" or "cgminer/5.0 DG2Plus"
+ *     Goldshell: "goldshell-miner/2.2.1" or "cgminer LT6"
+ *     Bitdeer:   "Sealminer/1.0.0 DL1"
+ *     Fluminer:  "fluminer/1.0 L1"
+ *     Unknown:   anything else → UNKNOWN tier, conservative defaults
+ *
+ * SECURITY NOTE:
+ *   User-agent CAN be spoofed. Model detection is advisory only —
+ *   it informs optimal difficulty starting point and vardiff floor.
+ *   It is never used for access control or payment decisions.
+ *
+ * VARDIFF TIERS (for unknown/fallback assignment):
+ *   HOME  < 2 GH/s  → startDiff: 8,192
+ *   MID   2–8 GH/s  → startDiff: 32,768
+ *   HIGH  8–20 GH/s → startDiff: 131,072
+ *   PRO   20+ GH/s  → startDiff: 524,288
  */
 
 const { createLogger } = require('../utils/logger');
-
 const log = createLogger('miner-registry');
 
-/**
- * ASIC model database
- * Each entry contains hardware specs, optimal pool settings,
- * and known firmware versions for update advisories.
- */
+// ─── Model database ───────────────────────────────────────────────────────────
+
 const MODELS = {
+
+  // ══════════════════════════════════════════════════════
+  // BITMAIN ANTMINER — SCRYPT SERIES
+  // ══════════════════════════════════════════════════════
+
   'antminer-l9': {
     name: 'Antminer L9',
     manufacturer: 'Bitmain',
-    expectedHashrate: 340e9,      // 340 GH/s
-    optimalDifficulty: 65536,
-    power: 3260,                   // watts
+    tier: 'HIGH',
+    expectedHashrateGhs: 16,
+    optimalDifficulty: 131072,
+    vardiffFloor: 65536,
+    power: 3360,
+    cooling: 'air',
     algorithm: 'scrypt',
-    // User-agent patterns (case-insensitive)
     patterns: [
-      /antminer\s*l9/i,
-      /bitmain.*l9/i,
-      /cgminer.*l9/i,
+      // (?![\dh]) rejects "L9H" (U2L9H); (?!\s*hydro) rejects "L9 Hydro"
+      /antminer[-_\s]*l9(?![\dh])(?!\s*hydro)/i,
+      /bitmain.*l9(?![\dh])(?!\s*hydro)/i,
+      /bmminer.*l9(?![\dh])(?!\s*hydro)/i,
+      /cgminer.*l9(?![\dh])(?!\s*hydro)/i,
     ],
     firmware: {
       current: '2025.11.1',
       supported: ['2025.11.1', '2025.08.2', '2025.05.1', '2024.12.1'],
-      critical: ['2024.06.0'],  // known vulnerable versions
+      critical: ['2024.06.0'],
     },
   },
+
+  'antminer-l11-pro': {
+    name: 'Antminer L11 Pro',
+    manufacturer: 'Bitmain',
+    tier: 'PRO',
+    expectedHashrateGhs: 21,
+    optimalDifficulty: 524288,
+    vardiffFloor: 262144,
+    power: 3612,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      /antminer[-_\s]*l11[-_\s]*pro/i,
+      /bmminer.*l11.*pro/i,
+      /cgminer.*l11.*pro/i,
+    ],
+    firmware: {
+      current: '2025.03.1',
+      supported: ['2025.03.1'],
+      critical: [],
+    },
+  },
+
+  'antminer-l11-hydro': {
+    name: 'Antminer L11 Hydro',
+    manufacturer: 'Bitmain',
+    tier: 'PRO',
+    expectedHashrateGhs: 33,
+    optimalDifficulty: 524288,
+    vardiffFloor: 524288,
+    power: 5676,
+    cooling: 'hydro',
+    algorithm: 'scrypt',
+    patterns: [
+      /antminer[-_\s]*l11[-_\s]*hydro/i,
+      /bmminer.*l11.*hydro/i,
+      /cgminer.*l11.*hydro/i,
+    ],
+    firmware: {
+      current: '2025.03.1',
+      supported: ['2025.03.1'],
+      critical: [],
+    },
+  },
+
+  'antminer-l11': {
+    name: 'Antminer L11',
+    manufacturer: 'Bitmain',
+    tier: 'PRO',
+    expectedHashrateGhs: 20,
+    optimalDifficulty: 524288,
+    vardiffFloor: 262144,
+    power: 3680,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      // NOTE: must come AFTER l11-pro and l11-hydro to avoid false matches
+      /antminer[-_\s]*l11(?![\s-]*pro)(?![\s-]*hydro)/i,
+      /bmminer.*l11(?![\s-]*pro)(?![\s-]*hydro)/i,
+      /cgminer.*l11(?![\s-]*pro)(?![\s-]*hydro)/i,
+    ],
+    firmware: {
+      current: '2025.03.1',
+      supported: ['2025.03.1', '2025.01.1'],
+      critical: [],
+    },
+  },
+
+  'antminer-u2l9h': {
+    name: 'Antminer U2L9H',
+    manufacturer: 'Bitmain',
+    tier: 'PRO',
+    expectedHashrateGhs: 27,
+    optimalDifficulty: 524288,
+    vardiffFloor: 262144,
+    power: 5670,
+    cooling: 'hydro',
+    algorithm: 'scrypt',
+    patterns: [
+      /u2l9h/i,
+      /antminer.*2u.*l9/i,
+      /antminer.*l9.*hydro/i,
+      /bmminer.*u2l9/i,
+    ],
+    firmware: {
+      current: '2025.05.1',
+      supported: ['2025.05.1', '2025.01.1'],
+      critical: [],
+    },
+  },
+
+  'antminer-l7-pro': {
+    name: 'Antminer L7 Pro',
+    manufacturer: 'Bitmain',
+    tier: 'HIGH',
+    expectedHashrateGhs: 9.5,
+    optimalDifficulty: 131072,
+    vardiffFloor: 65536,
+    power: 3425,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      /antminer[-_\s]*l7[-_\s]*pro/i,
+      /bmminer.*l7.*pro/i,
+      /cgminer.*l7.*pro/i,
+      /antminer[-_\s]*l7.*9\.5/i,
+    ],
+    firmware: {
+      current: '2024.08.1',
+      supported: ['2024.08.1', '2024.03.1'],
+      critical: [],
+    },
+  },
+
   'antminer-l7': {
     name: 'Antminer L7',
     manufacturer: 'Bitmain',
-    expectedHashrate: 9.5e9,       // 9.5 GH/s
-    optimalDifficulty: 8192,
+    tier: 'HIGH',
+    expectedHashrateGhs: 9.16,
+    optimalDifficulty: 131072,
+    vardiffFloor: 32768,
     power: 3425,
+    cooling: 'air',
     algorithm: 'scrypt',
     patterns: [
-      /antminer\s*l7/i,
-      /bitmain.*l7/i,
-      /cgminer.*l7/i,
+      // NOTE: must come AFTER l7-pro
+      /antminer[-_\s]*l7(?![-_\s]*pro)(?!.*9\.5)/i,
+      /bitmain.*l7(?![-_\s]*pro)/i,
+      /bmminer.*l7(?![-_\s]*pro)/i,
+      /cgminer.*l7(?![-_\s]*pro)/i,
     ],
     firmware: {
       current: '2024.08.1',
@@ -69,16 +207,21 @@ const MODELS = {
       critical: [],
     },
   },
+
   'antminer-l3plus': {
     name: 'Antminer L3+',
     manufacturer: 'Bitmain',
-    expectedHashrate: 504e6,       // 504 MH/s
+    tier: 'HOME',
+    expectedHashrateGhs: 0.504,
     optimalDifficulty: 512,
+    vardiffFloor: 256,
     power: 800,
+    cooling: 'air',
     algorithm: 'scrypt',
     patterns: [
-      /antminer\s*l3\+/i,
-      /antminer\s*l3plus/i,
+      /antminer[-_\s]*l3\+/i,
+      /antminer[-_\s]*l3plus/i,
+      /antminer[-_\s]*l3p/i,
       /bitmain.*l3/i,
       /cgminer.*l3/i,
     ],
@@ -88,16 +231,48 @@ const MODELS = {
       critical: ['2017.11.0'],
     },
   },
+
+  // ══════════════════════════════════════════════════════
+  // ELPHAPEX — DG SERIES
+  // ══════════════════════════════════════════════════════
+
+  'elphapex-dg2plus': {
+    name: 'ElphaPex DG2+',
+    manufacturer: 'ElphaPex',
+    tier: 'PRO',
+    expectedHashrateGhs: 20.5,
+    optimalDifficulty: 524288,
+    vardiffFloor: 262144,
+    power: 3900,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      /elphapex[-_\s]*dg2\+/i,
+      /elphapex[-_\s]*dg2plus/i,
+      /dg2\+/i,
+      /dg2plus/i,
+    ],
+    firmware: {
+      current: '2.0.0',
+      supported: ['2.0.0', '1.9.0'],
+      critical: [],
+    },
+  },
+
   'elphapex-dg2': {
     name: 'ElphaPex DG2',
     manufacturer: 'ElphaPex',
-    expectedHashrate: 36e9,        // 36 GH/s
-    optimalDifficulty: 16384,
+    tier: 'PRO',
+    expectedHashrateGhs: 20,
+    optimalDifficulty: 524288,
+    vardiffFloor: 131072,
     power: 2800,
+    cooling: 'air',
     algorithm: 'scrypt',
     patterns: [
-      /elphapex.*dg2/i,
-      /dg2/i,
+      // NOTE: must come AFTER dg2plus
+      /elphapex[-_\s]*dg2(?!\+)(?!plus)/i,
+      /(?<!\+)dg2(?!\+)(?!plus)/i,
     ],
     firmware: {
       current: '1.4.0',
@@ -105,33 +280,45 @@ const MODELS = {
       critical: [],
     },
   },
-  'elphapex-dg1': {
-    name: 'ElphaPex DG1',
+
+  'elphapex-dg-hydro1': {
+    name: 'ElphaPex DG Hydro 1',
     manufacturer: 'ElphaPex',
-    expectedHashrate: 14e9,        // 14 GH/s
-    optimalDifficulty: 4096,
-    power: 2000,
+    tier: 'PRO',
+    expectedHashrateGhs: 20,
+    optimalDifficulty: 524288,
+    vardiffFloor: 131072,
+    power: 6200,
+    cooling: 'hydro',
     algorithm: 'scrypt',
     patterns: [
-      /elphapex.*dg1/i,
-      /dg1[^0-9]/i,
+      /elphapex[-_\s]*dg[-_\s]*hydro[-_\s]*1/i,
+      /dg[-_\s]*hydro[-_\s]*1/i,
+      /dghydro1/i,
+      /elphapex.*hydro/i,
     ],
     firmware: {
-      current: '1.3.0',
-      supported: ['1.3.0', '1.2.0'],
+      current: '1.2.0',
+      supported: ['1.2.0', '1.1.0'],
       critical: [],
     },
   },
-  'volcminer-d1': {
-    name: 'VOLCMINER D1',
-    manufacturer: 'VOLCMINER',
-    expectedHashrate: 5e9,         // 5 GH/s
-    optimalDifficulty: 2048,
-    power: 1200,
+
+  'elphapex-dg1plus': {
+    name: 'ElphaPex DG1+',
+    manufacturer: 'ElphaPex',
+    tier: 'HIGH',
+    expectedHashrateGhs: 14.4,
+    optimalDifficulty: 131072,
+    vardiffFloor: 65536,
+    power: 3950,
+    cooling: 'air',
     algorithm: 'scrypt',
     patterns: [
-      /volcminer.*d1/i,
-      /volc.*d1/i,
+      /elphapex[-_\s]*dg1\+/i,
+      /elphapex[-_\s]*dg1plus/i,
+      /dg1\+/i,
+      /dg1plus/i,
     ],
     firmware: {
       current: '2.1.0',
@@ -139,16 +326,138 @@ const MODELS = {
       critical: [],
     },
   },
+
+  'elphapex-dg1': {
+    name: 'ElphaPex DG1',
+    manufacturer: 'ElphaPex',
+    tier: 'HIGH',
+    expectedHashrateGhs: 14,
+    optimalDifficulty: 65536,
+    vardiffFloor: 32768,
+    power: 2000,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      // NOTE: must come AFTER dg1plus
+      /elphapex[-_\s]*dg1(?!\+)(?!plus)/i,
+      /(?<!\+)dg1(?!\+)(?!plus)(?!m)/i,
+    ],
+    firmware: {
+      current: '1.3.0',
+      supported: ['1.3.0', '1.2.0'],
+      critical: [],
+    },
+  },
+
+  'elphapex-dg-home1': {
+    name: 'ElphaPex DG Home 1',
+    manufacturer: 'ElphaPex',
+    tier: 'MID',
+    expectedHashrateGhs: 6,
+    optimalDifficulty: 32768,
+    vardiffFloor: 8192,
+    power: 1500,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      /elphapex[-_\s]*dg[-_\s]*home[-_\s]*1/i,
+      /dg[-_\s]*home[-_\s]*1/i,
+      /dghome1/i,
+    ],
+    firmware: {
+      current: '1.1.0',
+      supported: ['1.1.0', '1.0.0'],
+      critical: [],
+    },
+  },
+
+  // ══════════════════════════════════════════════════════
+  // VOLCMINER
+  // ══════════════════════════════════════════════════════
+
+  'volcminer-d1-hydro': {
+    name: 'VolcMiner D1 Hydro',
+    manufacturer: 'VolcMiner',
+    tier: 'PRO',
+    expectedHashrateGhs: 30.4,
+    optimalDifficulty: 524288,
+    vardiffFloor: 524288,
+    power: 7600,
+    cooling: 'hydro',
+    algorithm: 'scrypt',
+    patterns: [
+      /volcminer[-_\s]*d1[-_\s]*hydro/i,
+      /volc[-_\s]*d1[-_\s]*hydro/i,
+      /d1[-_\s]*hydro/i,
+    ],
+    firmware: {
+      current: '3.0.0',
+      supported: ['3.0.0', '2.2.0'],
+      critical: [],
+    },
+  },
+
+  'volcminer-d3': {
+    name: 'VolcMiner D3',
+    manufacturer: 'VolcMiner',
+    tier: 'PRO',
+    expectedHashrateGhs: 20,
+    optimalDifficulty: 524288,
+    vardiffFloor: 131072,
+    power: 3560,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      /volcminer[-_\s]*d3/i,
+      /volc[-_\s]*d3/i,
+    ],
+    firmware: {
+      current: '2.1.0',
+      supported: ['2.1.0', '2.0.0'],
+      critical: [],
+    },
+  },
+
+  'volcminer-d1': {
+    name: 'VolcMiner D1',
+    manufacturer: 'VolcMiner',
+    tier: 'MID',
+    expectedHashrateGhs: 5,
+    optimalDifficulty: 32768,
+    vardiffFloor: 8192,
+    power: 1200,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      // NOTE: must come AFTER d1-hydro and d3
+      /volcminer[-_\s]*d1(?![-_\s]*hydro)/i,
+      /volc[-_\s]*d1(?![-_\s]*hydro)/i,
+    ],
+    firmware: {
+      current: '2.1.0',
+      supported: ['2.1.0', '2.0.0'],
+      critical: [],
+    },
+  },
+
+  // ══════════════════════════════════════════════════════
+  // GOLDSHELL — LT SERIES
+  // ══════════════════════════════════════════════════════
+
   'goldshell-lt6': {
     name: 'Goldshell LT6',
     manufacturer: 'Goldshell',
-    expectedHashrate: 3.35e9,      // 3.35 GH/s
-    optimalDifficulty: 1024,
-    power: 3200,
+    tier: 'MID',
+    expectedHashrateGhs: 8.5,
+    optimalDifficulty: 32768,
+    vardiffFloor: 16384,
+    power: 3350,
+    cooling: 'air',
     algorithm: 'scrypt',
     patterns: [
+      /goldshell[-_\s]*lt6/i,
       /goldshell.*lt6/i,
-      /lt6/i,
+      /lt6(?!pro)/i,
     ],
     firmware: {
       current: '2.2.1',
@@ -156,16 +465,20 @@ const MODELS = {
       critical: [],
     },
   },
+
   'goldshell-lt5pro': {
     name: 'Goldshell LT5 Pro',
     manufacturer: 'Goldshell',
-    expectedHashrate: 2.45e9,      // 2.45 GH/s
-    optimalDifficulty: 1024,
-    power: 3100,
+    tier: 'MID',
+    expectedHashrateGhs: 6,
+    optimalDifficulty: 32768,
+    vardiffFloor: 8192,
+    power: 2400,
+    cooling: 'air',
     algorithm: 'scrypt',
     patterns: [
-      /goldshell.*lt5\s*pro/i,
-      /lt5\s*pro/i,
+      /goldshell[-_\s]*lt5[-_\s]*pro/i,
+      /lt5[-_\s]*pro/i,
       /lt5pro/i,
     ],
     firmware: {
@@ -174,148 +487,262 @@ const MODELS = {
       critical: [],
     },
   },
+
+  'goldshell-lt5': {
+    name: 'Goldshell LT5',
+    manufacturer: 'Goldshell',
+    tier: 'MID',
+    expectedHashrateGhs: 4.3,
+    optimalDifficulty: 32768,
+    vardiffFloor: 8192,
+    power: 1700,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      // NOTE: must come AFTER lt5pro
+      /goldshell[-_\s]*lt5(?![-_\s]*pro)(?!pro)/i,
+      /(?<!pro[-_\s]*)lt5(?![-_\s]*pro)(?!pro)/i,
+    ],
+    firmware: {
+      current: '2.1.0',
+      supported: ['2.1.0', '2.0.0'],
+      critical: [],
+    },
+  },
+
+  'goldshell-lt-lite': {
+    name: 'Goldshell LT Lite',
+    manufacturer: 'Goldshell',
+    tier: 'HOME',
+    expectedHashrateGhs: 2,
+    optimalDifficulty: 8192,
+    vardiffFloor: 2048,
+    power: 600,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      /goldshell[-_\s]*lt[-_\s]*lite/i,
+      /lt[-_\s]*lite/i,
+      /ltlite/i,
+    ],
+    firmware: {
+      current: '1.1.0',
+      supported: ['1.1.0', '1.0.0'],
+      critical: [],
+    },
+  },
+
+  'goldshell-edg1m': {
+    name: 'Goldshell E-DG1M',
+    manufacturer: 'Goldshell',
+    tier: 'HOME',
+    expectedHashrateGhs: 1.2,
+    optimalDifficulty: 8192,
+    vardiffFloor: 1024,
+    power: 400,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      /goldshell[-_\s]*e[-_]?dg1m/i,
+      /e[-_]?dg1m/i,
+      /edg1m/i,
+    ],
+    firmware: {
+      current: '1.0.0',
+      supported: ['1.0.0'],
+      critical: [],
+    },
+  },
+
+  // ══════════════════════════════════════════════════════
+  // BITDEER — SEALMINER
+  // ══════════════════════════════════════════════════════
+
+  'bitdeer-sealminer-dl1': {
+    name: 'Bitdeer Sealminer DL1',
+    manufacturer: 'Bitdeer',
+    tier: 'HIGH',
+    expectedHashrateGhs: 12,
+    optimalDifficulty: 131072,
+    vardiffFloor: 32768,
+    power: 2800,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      /sealminer[-_\s]*dl1/i,
+      /bitdeer.*dl1/i,
+      /dl1[-_\s]*air/i,
+      /sealminer.*dl/i,
+    ],
+    firmware: {
+      current: '1.1.0',
+      supported: ['1.1.0', '1.0.0'],
+      critical: [],
+    },
+  },
+
+  // ══════════════════════════════════════════════════════
+  // FLUMINER
+  // ══════════════════════════════════════════════════════
+
+  'fluminer-l1': {
+    name: 'Fluminer L1',
+    manufacturer: 'Fluminer',
+    tier: 'MID',
+    expectedHashrateGhs: 5.6,
+    optimalDifficulty: 32768,
+    vardiffFloor: 8192,
+    power: 1300,
+    cooling: 'air',
+    algorithm: 'scrypt',
+    patterns: [
+      /fluminer[-_\s]*l1/i,
+      /fluminer.*l1/i,
+    ],
+    firmware: {
+      current: '1.0.0',
+      supported: ['1.0.0'],
+      critical: [],
+    },
+  },
 };
+
+// ─── Vardiff tier fallback table (for unrecognized miners) ────────────────────
+
+const UNKNOWN_DEFAULTS = {
+  optimalDifficulty: 32768,
+  vardiffFloor: 8192,
+};
+
+// ─── Pattern match order ─────────────────────────────────────────────────────
+// Models are evaluated in insertion order (V8 preserves this for non-integer
+// keys). More specific patterns must appear before base variants.
+
+const MODEL_KEYS = Object.keys(MODELS);
+
+// ─── MinerRegistry class ─────────────────────────────────────────────────────
 
 class MinerRegistry {
   constructor() {
     this.models = MODELS;
-    this.detectionCache = new Map(); // userAgent → model key (LRU-ish)
+    this.unknownDefaults = UNKNOWN_DEFAULTS;
+    this._cache = new Map();
+    this._cacheMax = 2000;
   }
 
   /**
-   * Identify miner model from user-agent string.
-   * User-agents vary by firmware: cgminer, bmminer, cpuminer, custom.
-   * Examples:
-   *   "cgminer/4.11.1 L9"
-   *   "bmminer/2.0.0 Antminer L7"
-   *   "ElphaPex DG2 v1.4.0"
-   *
-   * @param {string} userAgent - Raw user-agent from mining.subscribe
-   * @returns {object|null} Model profile or null if unrecognized
+   * Identify miner model from the user-agent string sent in mining.subscribe.
    */
   identify(userAgent) {
     if (!userAgent || typeof userAgent !== 'string') return null;
 
-    // Check cache first
-    if (this.detectionCache.has(userAgent)) {
-      const key = this.detectionCache.get(userAgent);
+    const ua = userAgent.trim();
+
+    if (this._cache.has(ua)) {
+      const key = this._cache.get(ua);
       return key ? { key, ...this.models[key] } : null;
     }
 
-    // Try each model's patterns
-    for (const [key, model] of Object.entries(this.models)) {
-      for (const pattern of model.patterns) {
-        if (pattern.test(userAgent)) {
-          this.detectionCache.set(userAgent, key);
-
-          // Cap cache size
-          if (this.detectionCache.size > 1000) {
-            const firstKey = this.detectionCache.keys().next().value;
-            this.detectionCache.delete(firstKey);
-          }
-
-          log.info({ model: model.name, userAgent }, 'Miner model identified');
-          return { key, ...model };
+    for (const key of MODEL_KEYS) {
+      for (const pattern of this.models[key].patterns) {
+        if (pattern.test(ua)) {
+          this._cacheSet(ua, key);
+          log.info({ model: this.models[key].name, userAgent: ua }, 'Miner model identified');
+          return { key, ...this.models[key] };
         }
       }
     }
 
-    // Unknown model
-    this.detectionCache.set(userAgent, null);
-    log.debug({ userAgent }, 'Unknown miner model');
+    this._cacheSet(ua, null);
+    log.debug({ userAgent: ua }, 'Unknown miner model — applying universal defaults');
     return null;
   }
 
-  /**
-   * Extract firmware version from user-agent string.
-   * Common patterns:
-   *   "cgminer/4.11.1" → "4.11.1"
-   *   "bmminer/2.0.0"  → "2.0.0"
-   *   "v1.4.0"         → "1.4.0"
-   */
+  /** Extract firmware version from user-agent string. */
   extractFirmwareVersion(userAgent) {
     if (!userAgent) return null;
 
-    // Try common version patterns
     const patterns = [
-      /(?:cgminer|bmminer|cpuminer|sgminer)[\/\s](\d+\.\d+\.\d+)/i,
-      /v(\d+\.\d+\.\d+)/i,
-      /(\d{4}\.\d{1,2}\.\d+)/,  // date-based versions like 2025.11.1
-      /(\d+\.\d+\.\d+)/,        // generic semver
+      /(?:cgminer|bmminer|cpuminer|sgminer|fluminer|sealminer)[/\s](\d+\.\d+\.\d+)/i,
+      /[vV](\d+\.\d+\.\d+)/,
+      /(\d{4}\.\d{1,2}\.\d+)/,
+      /(\d+\.\d+\.\d+)/,
     ];
 
-    for (const pattern of patterns) {
-      const match = userAgent.match(pattern);
-      if (match) return match[1];
+    for (const p of patterns) {
+      const m = userAgent.match(p);
+      if (m) return m[1];
     }
-
     return null;
   }
 
-  /**
-   * Check if a firmware version is outdated for a given model.
-   * @returns {{ outdated: boolean, critical: boolean, current: string }}
-   */
+  /** Check firmware status for a detected model. */
   checkFirmwareStatus(modelKey, version) {
     const model = this.models[modelKey];
-    if (!model || !version) return { outdated: false, critical: false, current: null };
-
-    const isCritical = model.firmware.critical.includes(version);
-    const isSupported = model.firmware.supported.includes(version);
-    const isCurrent = version === model.firmware.current;
+    if (!model || !version) return { outdated: false, critical: false, current: null, supported: false };
 
     return {
-      outdated: !isCurrent,
-      critical: isCritical,
+      outdated: version !== model.firmware.current,
+      critical: model.firmware.critical.includes(version),
       current: model.firmware.current,
-      supported: isSupported,
+      supported: model.firmware.supported.includes(version),
     };
   }
 
-  /**
-   * Get optimal starting difficulty for a model.
-   * Reduces VarDiff convergence from ~5 retargets to ~1.
-   */
+  /** Get the optimal starting difficulty for a model. */
   getOptimalDifficulty(modelKey) {
-    const model = this.models[modelKey];
-    return model ? model.optimalDifficulty : null;
+    if (!modelKey || !this.models[modelKey]) return this.unknownDefaults.optimalDifficulty;
+    return this.models[modelKey].optimalDifficulty;
   }
 
-  /**
-   * Get expected hashrate for efficiency comparison.
-   */
+  /** Get the vardiff floor for a model. */
+  getVardiffFloor(modelKey) {
+    if (!modelKey || !this.models[modelKey]) return this.unknownDefaults.vardiffFloor;
+    return this.models[modelKey].vardiffFloor;
+  }
+
+  /** Get expected hashrate in GH/s for efficiency monitoring. */
   getExpectedHashrate(modelKey) {
-    const model = this.models[modelKey];
-    return model ? model.expectedHashrate : null;
+    if (!modelKey || !this.models[modelKey]) return null;
+    return this.models[modelKey].expectedHashrateGhs;
   }
 
-  /**
-   * Get all registered models for dashboard display.
-   */
-  getAllModels() {
-    return Object.entries(this.models).map(([key, model]) => ({
-      key,
-      name: model.name,
-      manufacturer: model.manufacturer,
-      expectedHashrate: model.expectedHashrate,
-      optimalDifficulty: model.optimalDifficulty,
-      power: model.power,
-      currentFirmware: model.firmware.current,
-    }));
+  /** Get tier string for a model key (HOME|MID|HIGH|PRO). */
+  getTier(modelKey) {
+    if (!modelKey || !this.models[modelKey]) return 'UNKNOWN';
+    return this.models[modelKey].tier;
   }
 
-  /**
-   * Get model-aware minimum difficulty floor.
-   * Prevents VarDiff gaming: L9 cannot go below 8192.
-   * Addresses documented 6.5M shares/sec exploit at diff=0.001.
-   */
-  getDifficultyFloor(modelKey) {
-    const model = this.models[modelKey];
-    if (!model) return 64; // default minimum
+  /** Returns a summary of all registered models for API/dashboard use. */
+  listModels() {
+    return MODEL_KEYS.map(key => {
+      const m = this.models[key];
+      return {
+        key,
+        name: m.name,
+        manufacturer: m.manufacturer,
+        tier: m.tier,
+        expectedHashrateGhs: m.expectedHashrateGhs,
+        optimalDifficulty: m.optimalDifficulty,
+        vardiffFloor: m.vardiffFloor,
+        power: m.power,
+        cooling: m.cooling,
+      };
+    });
+  }
 
-    // Floor = optimal / 8 (allows some headroom but prevents gaming)
-    return Math.max(64, Math.floor(model.optimalDifficulty / 8));
+  // ─── Back-compat aliases (v0.7.x callers still using these names) ─────────
+  getAllModels()               { return this.listModels(); }
+  getDifficultyFloor(modelKey) { return this.getVardiffFloor(modelKey); }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  _cacheSet(ua, key) {
+    if (this._cache.size >= this._cacheMax) {
+      this._cache.delete(this._cache.keys().next().value);
+    }
+    this._cache.set(ua, key);
   }
 }
 
-module.exports = MinerRegistry;
+module.exports = new MinerRegistry();

--- a/src/pool/securityEngine.js
+++ b/src/pool/securityEngine.js
@@ -38,6 +38,7 @@
 const crypto      = require('crypto');
 const EventEmitter = require('events');
 const { createLogger } = require('../utils/logger');
+const poolLogger = require('../logging/poolLogger');
 
 const log = createLogger('security-engine');
 
@@ -1234,11 +1235,31 @@ class SecurityEngine extends EventEmitter {
       if (this.deps.banningManager && ctx.ip) {
         this.deps.banningManager.ban(ctx.ip, finding.reason);
       }
+      // v0.8.2 event codes
+      poolLogger.emit('SEC_002', { ip: ctx.ip, address: ctx.address, reason: finding.reason, layer: finding.layer });
+      if (finding.layer === 4) {
+        poolLogger.emit('SEC_004', { address: ctx.address, ip: ctx.ip, reason: finding.reason });
+      }
     } else if (finding.result === RESULT.FLAG) {
       log.info({ ...ctx, reason: finding.reason, layer: finding.layer }, '⚑  Security flag');
       this.emit('flag', event);
+      // v0.8.2 event codes
+      if (finding.layer === 4) {
+        poolLogger.emit('SEC_004', { address: ctx.address, ip: ctx.ip, reason: finding.reason });
+      } else if (finding.layer === 5 && /sybil/i.test(finding.reason || '')) {
+        poolLogger.emit('SEC_003', { ip: ctx.ip, reason: finding.reason });
+      } else if (finding.layer === 6) {
+        poolLogger.emit('SEC_001', { ip: ctx.ip, clientId: ctx.clientId, reason: finding.reason });
+      } else if (finding.layer === 7 && /address/i.test(finding.reason || '')) {
+        poolLogger.emit('SEC_005', { address: ctx.address, ip: ctx.ip, reason: finding.reason });
+      }
     } else if (finding.result === RESULT.REJECT) {
       log.debug({ ...ctx, reason: finding.reason, layer: finding.layer }, '✗  Share rejected');
+      if (finding.layer === 6) {
+        poolLogger.emit('SEC_001', { ip: ctx.ip, clientId: ctx.clientId, reason: finding.reason });
+      } else if (finding.layer === 7 && /address/i.test(finding.reason || '')) {
+        poolLogger.emit('SEC_005', { address: ctx.address, ip: ctx.ip, reason: finding.reason });
+      }
     }
 
     return finding;

--- a/src/pool/shareProcessor.js
+++ b/src/pool/shareProcessor.js
@@ -6,6 +6,7 @@
 
 const EventEmitter = require('events');
 const { createLogger } = require('../utils/logger');
+const poolLogger = require('../logging/poolLogger');
 const { STRATUM } = require('../ux/copy');
 const {
   sha256d,
@@ -56,12 +57,14 @@ class ShareProcessor extends EventEmitter {
       if (!/^[0-9a-fA-F]{8}$/.test(nonce)) {
         client.rejectShare(share.id, STRATUM.errors.LOW_DIFFICULTY.code, 'Invalid nonce format');
         this._recordShare(client, share, null, 'rejected', 'bad nonce').catch(() => {});
+        poolLogger.emit('SHARE_005', { address: client.minerAddress, worker: client.workerName, reason: 'bad nonce' });
         this.emit('invalidShare', client, share, 'bad nonce');
         return;
       }
       if (!/^[0-9a-fA-F]{8}$/.test(extraNonce2)) {
         client.rejectShare(share.id, STRATUM.errors.LOW_DIFFICULTY.code, 'Invalid extraNonce2 format');
         this._recordShare(client, share, null, 'rejected', 'bad extraNonce2').catch(() => {});
+        poolLogger.emit('SHARE_005', { address: client.minerAddress, worker: client.workerName, reason: 'bad extraNonce2' });
         this.emit('invalidShare', client, share, 'bad extraNonce2');
         return;
       }
@@ -72,6 +75,7 @@ class ShareProcessor extends EventEmitter {
         client.rejectShare(share.id, STRATUM.errors.JOB_NOT_FOUND.code, STRATUM.errors.JOB_NOT_FOUND.message);
         client.shares.stale++;
         this._recordShare(client, share, null, 'stale', 'job not found').catch(() => {});
+        poolLogger.emit('SHARE_002', { address: client.minerAddress, worker: client.workerName, jobId });
         this.emit('staleShare', client, share);
         return;
       }
@@ -82,6 +86,7 @@ class ShareProcessor extends EventEmitter {
       const isDup = await this.dedup.isDuplicate(extraNonce1, extraNonce2, ntime, nonce, jobId);
       if (isDup) {
         client.rejectShare(share.id, STRATUM.errors.DUPLICATE_SHARE.code, STRATUM.errors.DUPLICATE_SHARE.message);
+        poolLogger.emit('SHARE_004', { address: client.minerAddress, worker: client.workerName, nonce });
         this.emit('duplicateShare', client, share);
         return;
       }
@@ -91,6 +96,7 @@ class ShareProcessor extends EventEmitter {
       const now = Math.floor(Date.now() / 1000);
       if (Math.abs(ntimeInt - now) > 600) {
         client.rejectShare(share.id, STRATUM.errors.INVALID_NTIME.code, STRATUM.errors.INVALID_NTIME.message);
+        poolLogger.emit('SHARE_005', { address: client.minerAddress, worker: client.workerName, reason: 'bad ntime' });
         this.emit('invalidShare', client, share, 'bad ntime');
         return;
       }
@@ -108,12 +114,20 @@ class ShareProcessor extends EventEmitter {
       if (!meetsTarget(hash, shareTarget)) {
         client.rejectShare(share.id, STRATUM.errors.LOW_DIFFICULTY.code, STRATUM.errors.LOW_DIFFICULTY.message);
         this._recordShare(client, share, template, 'rejected', 'low difficulty').catch(() => {});
+        poolLogger.emit('SHARE_003', {
+          address: client.minerAddress, worker: client.workerName,
+          submittedDiff: share.difficulty, requiredDiff: client.difficulty,
+        });
         this.emit('invalidShare', client, share, 'low difficulty');
         return;
       }
 
       // ── Step 6: Share is valid ──
       client.acceptShare(share.id);
+      poolLogger.emit('SHARE_001', {
+        address: client.minerAddress, worker: client.workerName,
+        diff: share.difficulty, jobId,
+      });
 
       // Update VarDiff
       const vardiffRatio = client.vardiff.recordShare();
@@ -125,6 +139,15 @@ class ShareProcessor extends EventEmitter {
             oldDiff: client.difficulty,
             newDiff,
           }, 'VarDiff adjustment');
+          const oldDiff = client.difficulty;
+          if (newDiff > oldDiff) {
+            poolLogger.emit('VARDIFF_001', { address: client.minerAddress, worker: client.workerName, from: oldDiff, to: newDiff });
+          } else {
+            poolLogger.emit('VARDIFF_002', { address: client.minerAddress, worker: client.workerName, from: oldDiff, to: newDiff });
+          }
+          if (client.vardiff.maxDiff && newDiff >= client.vardiff.maxDiff) {
+            poolLogger.emit('VARDIFF_004', { address: client.minerAddress, worker: client.workerName, diff: newDiff });
+          }
           client.sendDifficulty(newDiff);
         }
       }
@@ -257,6 +280,8 @@ class ShareProcessor extends EventEmitter {
       const blockHex = Buffer.concat(parts).toString('hex');
 
       // Submit to daemon
+      // BLOCK_001: submission attempt
+      poolLogger.emit('BLOCK_001', { height: template.height, chain: 'LTC' });
       const result = await this.rpc.submitBlock(blockHex);
 
       if (result === null || result === undefined) {
@@ -265,11 +290,19 @@ class ShareProcessor extends EventEmitter {
           worker: client.workerName,
           reward: template.coinbasevalue / 1e8,
         }, '✅ Block accepted by network!');
+        poolLogger.emit('BLOCK_002', {
+          height: template.height,
+          hash: require('../utils/hashing').reverseBuffer(require('../utils/hashing').sha256d(header)).toString('hex'),
+          reward: template.coinbasevalue / 1e8,
+          worker: client.workerName,
+          chain: 'LTC',
+        });
 
         await this._recordBlock(template, client, header);
         this.emit('blockFound', template, client);
       } else {
         log.error({ result, height: template.height }, '❌ Block rejected by network');
+        poolLogger.emit('BLOCK_003', { height: template.height, reason: result, chain: 'LTC' });
         this.emit('blockRejected', template, client, result);
       }
 

--- a/src/stratum/server.js
+++ b/src/stratum/server.js
@@ -8,6 +8,7 @@ const net = require('net');
 const crypto = require('crypto');
 const EventEmitter = require('events');
 const { createLogger } = require('../utils/logger');
+const poolLogger = require('../logging/poolLogger');
 const VarDiffManager = require('./vardiff');
 const { STRATUM } = require('../ux/copy');
 
@@ -116,6 +117,7 @@ class StratumClient extends EventEmitter {
           this._handleMessage(message);
         } catch (err) {
           log.warn({ ip: this.remoteAddress, raw: line.substring(0, 100) }, 'Malformed stratum message');
+          poolLogger.emit('CONN_004', { ip: this.remoteAddress, raw: line.substring(0, 100) });
           this.shares.invalid++;
         }
       }
@@ -140,6 +142,7 @@ class StratumClient extends EventEmitter {
 
     this.socket.on('timeout', () => {
       log.info({ ip: this.remoteAddress, worker: this.workerName }, 'Connection timeout');
+      poolLogger.emit('CONN_003', { ip: this.remoteAddress, worker: this.workerName, address: this.minerAddress });
       this.disconnect('timeout');
     });
 
@@ -229,6 +232,7 @@ class StratumClient extends EventEmitter {
     const [workerName, password] = msg.params || [];
 
     if (!workerName) {
+      poolLogger.emit('CONN_006', { ip: this.remoteAddress, reason: 'missing worker name' });
       this._sendResponse(msg.id, false);
       this._sendError(msg.id, STRATUM.errors.UNAUTHORIZED.code, STRATUM.errors.UNAUTHORIZED.message);
       return;
@@ -246,6 +250,7 @@ class StratumClient extends EventEmitter {
       const validation = validateAddress(this.minerAddress);
       if (!validation.valid) {
         log.warn({ address: this.minerAddress, error: validation.error }, 'Rejected — invalid LTC address');
+        poolLogger.emit('CONN_006', { address: this.minerAddress, ip: this.remoteAddress, reason: validation.error });
         this._sendResponse(msg.id, false);
         this._sendError(msg.id, STRATUM.errors.UNAUTHORIZED.code, 'Invalid Litecoin address — check worker format');
         return;
@@ -262,6 +267,7 @@ class StratumClient extends EventEmitter {
       worker: this.workerName,
       address: this.minerAddress,
     }, 'Worker authorized');
+    poolLogger.emit('CONN_005', { worker: this.workerName, address: this.minerAddress, ip: this.remoteAddress });
 
     this._sendResponse(msg.id, true);
     this.emit('authorize', this, workerName, password);
@@ -507,6 +513,7 @@ class StratumServer extends EventEmitter {
       extraNonce1,
       activeClients: this.clients.size,
     }, 'New miner connection');
+    poolLogger.emit('CONN_001', { ip, clientId: client.id, activeClients: this.clients.size });
 
     // ── Event wiring ──
 
@@ -543,6 +550,7 @@ class StratumServer extends EventEmitter {
         uptime: Date.now() - c.connectedAt,
         activeClients: this.clients.size,
       }, 'Miner disconnected');
+      poolLogger.emit('CONN_002', { worker: c.workerName, ip, address: c.minerAddress, uptime: Date.now() - c.connectedAt });
 
       this.emit('disconnect', c);
     });
@@ -560,6 +568,7 @@ class StratumServer extends EventEmitter {
       }
     }
     log.info({ jobId: job.jobId, miners: count }, 'Job broadcast');
+    poolLogger.emit('BLOCK_005', { jobId: job.jobId, miners: count, height: job.height });
   }
 
   /**

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -7,7 +7,7 @@ const pino = require('pino');
 const config = require('../../config');
 
 const logger = pino({
-  level: config.monitoring.logLevel,
+  level: process.env.LOG_LEVEL || (config.monitoring && config.monitoring.logLevel) || 'info',
   transport: config.env === 'development'
     ? { target: 'pino-pretty', options: { colorize: true, translateTime: 'SYS:HH:MM:ss' } }
     : undefined,


### PR DESCRIPTION
## Summary

Delivers the v0.8.2 observability pillar: a 55-event logging registry that fans a single `poolLogger.emit(code, data)` call out to pino, PostgreSQL, Prometheus, email/Telegram/webhook alerts, and a `/ws/events` WebSocket stream. Also expands the ASIC miner registry from 8 → 24 profiles and fixes two pre-existing v0.8.0/v0.8.1 regressions that prevented the pool from booting.

## What's in this PR

### New
- **`src/logging/eventCodes.js`** — 55-event registry (CONN, SHARE, BLOCK, AUX, DAEMON, VARDIFF, PAY, SEC, SYS categories)
- **`src/logging/poolLogger.js`** — central emit singleton; fans out to 5 channels, each non-blocking and non-throwing
- **`src/logging/metricsExporter.js`** — prom-client registry with auto-registered counters + shared gauges + histograms; back-compat shim provides the `recordShare`/`recordBlock` API that `src/index.js` was already calling against an undefined `prom` object
- **`src/logging/alertDelivery.js`** — SMTP (nodemailer), Telegram (direct `fetch`), and generic webhook; per-`(code,chain)` 5-minute cooldown (configurable) to prevent storms; uses `Promise.allSettled` so one channel's failure never affects the others
- **`src/logging/logDelivery.js`** — separate `ws.Server` on path `/ws/events` so log streams cannot back-pressure the existing dashboard WebSocket
- **`migrations/012_pool_events.js`** — `pool_events` table + 6 indexes + 5 views (`v_recent_errors`, `v_event_summary_1h`, `v_block_history`, `v_payment_log`, `v_security_log`) + `pool_events_prune()` function

### Modified (emit-call insertion sites)
- `src/stratum/server.js` — `CONN_001..006`, `BLOCK_005`
- `src/pool/shareProcessor.js` — `SHARE_001..005`, `BLOCK_001/002/003`, `VARDIFF_001/002/004`
- `src/blockchain/rpcClient.js` — `DAEMON_002/003/005/006/007/008`
- `src/blockchain/auxpow.js` — `AUX_001/002/003/004`
- `src/payment/paymentProcessor.js` — `PAY_001/002/003/005`
- `src/pool/securityEngine.js` — `SEC_001..005` inside the `_handle` dispatcher
- `src/api/server.js` — `SYS_008` on 500 + new `GET /api/v1/models` endpoint
- `src/index.js` — wires `setPg` / `setMetrics`, attaches `logDelivery` + `/metrics` route, emits `SYS_001/002` on startup/shutdown, replaces 5 undefined `prom.*` calls with `metricsExporter.*`

### ASIC Registry (`src/pool/minerRegistry.js`)
Full replacement. 8 → 24 profiles (spec header said "20"; the delivered file actually contains 24). New API: `listModels()`, `getVardiffFloor()`, `getTier()`, `getExpectedHashrate()`. Back-compat aliases preserve `getAllModels()` and `getDifficultyFloor()` for existing callers. L9 patterns were tightened to prevent false-positive matches on `U2L9H` and `L9 Hydro`.

### Pre-existing regressions fixed (required for boot)
1. **`src/utils/logger.js`** — crashed on `config.monitoring.logLevel` being undefined (leftover from the Prometheus removal cleanup)
2. **`src/api/routes/extended.js:8`** — `require('../../config/coins')` resolved to `src/config/coins` which doesn't exist; corrected to `'../../../config/coins'` to match sibling route files

### Config / infra
- `.env.example` — adds `ALERT_COOLDOWN_MINUTES`, full `ALERT_EMAIL_*` block, `ALERT_TELEGRAM_*`, `ALERT_WEBHOOK_*`, and `LOG_LEVEL`
- `docker/docker-compose.prod.yml` — log driver bumped from `max-size: 50m`/`max-file: 5` to `100m`/`10` (events are verbose)
- `package.json` — adds `nodemailer@^6.9.0` + `prom-client@^15.1.3`; version bumped to `0.8.2`

## Verification

All checks run locally before this PR:

```
$ node -e "console.log(Object.keys(require('./src/logging/eventCodes').EVENTS).length)"
55

$ for m in eventCodes metricsExporter alertDelivery poolLogger logDelivery; do
    node -e "require('./src/logging/$m')" && echo OK
  done
# → all OK

$ grep -n "\bprom\." src/index.js
# (empty — previously had 5 undefined refs)

$ node -e "/* full WebSocket round-trip */"
registry size: PASS
event received: BLOCK_002

$ node src/index.js     # with correct env
# boots past entire require chain; fails only on ECONNREFUSED 5432 (expected here)
```

- **55 events** registered
- **24 models** in minerRegistry; 23/23 user-agent detection tests pass (`L9`, `U2L9H`, `L11 Pro` vs `L11 Hydro` vs base `L11`, all `DG*`, `LT5` vs `LT5 Pro`, etc.)
- **Cooldown** confirmed: same `DAEMON_006` within 5 min → second send suppressed
- **Metrics route** returns Prometheus text format with `pool_shares_accepted_total` and `pool_node_*` default metrics

## Test plan

- [ ] Review `src/logging/poolLogger.js` — confirm the 5-channel fan-out is acceptable (stdout always, PG when persist && wired, Prometheus always, alerts on warn+, bus always)
- [ ] Review `src/logging/alertDelivery.js` cooldown logic and env var names
- [ ] Confirm `migrations/012_pool_events.js` DDL (indexes, views, pruning retention: blocks/payments forever, info/warn 14d, errors 90d)
- [ ] Run `npm run migrate` against production Postgres to create `pool_events`
- [ ] Set `ALERT_TELEGRAM_*` env vars on the OVHCloud host and emit a test event to verify delivery
- [ ] Confirm `/metrics` and `/ws/events` are reachable (likely behind nginx)
- [ ] Confirm `GET /api/v1/models` returns 24 entries

## Notes for reviewer

- **Do not merge** — this PR is for Aqua to review and merge manually. Wanted CI + eyes on the `prom.*` → `metricsExporter.*` swap and the `minerRegistry` replacement before landing.
- **Migration needs to be run** after merge: `node migrations/run.js` (creates `pool_events` and all views).
- **No `.env` changes are required on hosts** that don't want alerts — all alert channels default to `false`.
- **Setup guides** for Gmail App Password and `@BotFather` Telegram bot are in the original handoff document (not duplicated here); happy to add them to the repo docs if wanted.

https://claude.ai/code/session_01Cwf8pgMTg2787RpxJRfU7t