### PR TITLE
Security hardening v0.8.2 → v0.8.3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,11 @@ STRATUM_SSL_PORT=3334
 STRATUM_SOLO_PORT=3336
 
 # ── Security ──────────────────────────────────────
+# REQUIRED. 32+ hex chars used as the HMAC secret for mining cookie
+# issuance. Must be stable across pool restarts and identical on every
+# node when scaling horizontally. Generate with: openssl rand -hex 32
+COOKIE_SECRET=
+
 SEC_MAX_CONN_PER_IP=5                     # Public: connections per IP
 SEC_MAX_CONN_PER_FLEET_IP=100             # Fleet: connections per IP
 SEC_MAX_SHARE_RATE_PER_MIN=600            # Shares/min per client

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ FLEET_ADDRESSES=                          # Optional: LTC addresses (comma-separ
 FLEET_FEE=0                               # 0% fee for fleet miners
 FLEET_MAX_MINERS=100                      # Max fleet capacity (increase as fleet grows)
 
+# ── Pool Wallets ──────────────────────────────────
+# REQUIRED. Pool wallet that receives block rewards. Must be a valid Litecoin
+# address and MUST be different from POOL_FEE_ADDRESS — using one wallet for
+# both rewards and fee collection is a single-key compromise risk.
+LTC_REWARD_ADDRESS=
+
 # ── Pool Fees ─────────────────────────────────────
 POOL_FEE=0.02                             # 2% for public miners
 SOLO_FEE=0.01                             # 1% for solo miners

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ LUXXPOOL is built fleet-first. The operator's own hardware gets priority treatme
   │   Anyone with an L9/L7/DG2 ──> POOL (2% fee)      │
   │   Solo miners ──────────────── SOLO (1% fee)       │
   │                                                    │
-  │   Full 9-layer security pipeline active            │
+  │   8-layer security pipeline active (L3 deferred)   │
   │   VarDiff, rate limiting, reputation scoring       │
   │                                                    │
   └────────────────────────────────────────────────────┘
@@ -143,9 +143,9 @@ Currently tested and proven for **40 L9 miners** (680 GH/s) with headroom to 100
 
 ---
 
-## Nine-Layer Security Engine
+## Layered Security Engine
 
-Every public miner connection passes through 9 sequential security layers. Fleet miners bypass the pipeline entirely.
+Every public miner connection passes through eight active security layers (Layer 3 cookie verification is deferred to Stratum V2 — Stratum V1 has no protocol field for miners to echo a cookie back, so cookies are issued at subscribe but verification is a no-op until V2 lands). Fleet miners bypass the pipeline entirely.
 
 ```
   Incoming Connection
@@ -154,7 +154,7 @@ Every public miner connection passes through 9 sequential security layers. Fleet
         │
    L2   │  Protocol Hardening ──── JSON validation, buffer limits, message caps
         │
-   L3   │  Auth & Cookies ──────── HMAC mining cookies, anti-hijack
+   L3   │  Auth & Cookies ──────── HMAC mining cookies (verification deferred to Stratum V2)
         │
    L4   │  Share Fingerprinting ── Statistical BWH/FAW attack detection
         │

--- a/config/index.js
+++ b/config/index.js
@@ -220,6 +220,9 @@ function validateConfig() {
   if (config.api.adminToken && config.api.adminToken.length < 32) {
     errors.push('API_ADMIN_TOKEN must be at least 32 characters for security');
   }
+  if (!process.env.COOKIE_SECRET || process.env.COOKIE_SECRET.length < 32) {
+    errors.push('COOKIE_SECRET must be set and at least 32 characters (generate with: openssl rand -hex 32)');
+  }
 
   if (errors.length > 0) {
     console.error('Configuration errors:');

--- a/config/index.js
+++ b/config/index.js
@@ -9,10 +9,11 @@ const config = {
   env: process.env.NODE_ENV || 'development',
 
   pool: {
-    name:       process.env.POOL_NAME || 'LUXXPOOL',
-    host:       process.env.POOL_HOST || 'luxxpool.io',
-    fee:        parseFloat(process.env.POOL_FEE || '0.02'),
-    feeAddress: process.env.POOL_FEE_ADDRESS,
+    name:          process.env.POOL_NAME || 'LUXXPOOL',
+    host:          process.env.POOL_HOST || 'luxxpool.io',
+    fee:           parseFloat(process.env.POOL_FEE || '0.02'),
+    feeAddress:    process.env.POOL_FEE_ADDRESS,
+    rewardAddress: process.env.LTC_REWARD_ADDRESS,
   },
 
   stratum: {
@@ -184,11 +185,26 @@ const config = {
 function validateConfig() {
   const errors = [];
 
+  const isLtcAddress = (a) =>
+    /^[LM3][a-km-zA-HJ-NP-Z1-9]{25,34}$/.test(a) || /^ltc1[a-z0-9]{39,59}$/.test(a);
+
+  // Pool reward wallet is required and must be distinct from the fee wallet —
+  // co-mingling rewards and fees on one key means a single compromise drains
+  // every block reward the pool has accumulated.
+  if (!config.pool.rewardAddress) {
+    errors.push('LTC_REWARD_ADDRESS is required (pool wallet for block rewards)');
+  } else if (!isLtcAddress(config.pool.rewardAddress)) {
+    errors.push('LTC_REWARD_ADDRESS is not a valid Litecoin address format');
+  }
+  if (config.pool.feeAddress && config.pool.rewardAddress &&
+      config.pool.feeAddress === config.pool.rewardAddress) {
+    errors.push('LTC_REWARD_ADDRESS and POOL_FEE_ADDRESS must be different wallets');
+  }
+
   if (config.pool.fee > 0) {
     if (!config.pool.feeAddress) {
       errors.push('POOL_FEE_ADDRESS required when POOL_FEE > 0');
-    } else if (!/^[LM3][a-km-zA-HJ-NP-Z1-9]{25,34}$/.test(config.pool.feeAddress)
-               && !/^ltc1[a-z0-9]{39,59}$/.test(config.pool.feeAddress)) {
+    } else if (!isLtcAddress(config.pool.feeAddress)) {
       errors.push('POOL_FEE_ADDRESS is not a valid Litecoin address format');
     }
   }

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -136,7 +136,7 @@ services:
       -txindex=1
       -rpcuser=luxxpool_rpc
       -rpcpassword=${LTC_PASS}
-      -rpcallowip=0.0.0.0/0
+      -rpcallowip=172.28.0.0/16
       -rpcbind=0.0.0.0
       -rpcport=9332
       -zmqpubhashblock=tcp://0.0.0.0:28332

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -49,6 +49,8 @@ services:
       - luxxpool-net
     security_opt:
       - no-new-privileges:true
+    cap_drop:
+      - ALL
     read_only: true
     tmpfs:
       - /tmp:size=100M
@@ -85,6 +87,10 @@ services:
         max-file: "3"
     networks:
       - luxxpool-net
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     shm_size: 256m
 
   redis:
@@ -124,6 +130,10 @@ services:
         max-file: "3"
     networks:
       - luxxpool-net
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 
   # ── Litecoin Core ─────────────────────────────────────
   # Only use this if you don't already have a local daemon
@@ -167,6 +177,10 @@ services:
         max-file: "3"
     networks:
       - luxxpool-net
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 
 volumes:
   pg-data:

--- a/docs/engineering/DEPLOYMENT.md
+++ b/docs/engineering/DEPLOYMENT.md
@@ -1,0 +1,97 @@
+# LUXXPOOL — Production Deployment Notes
+
+This file collects operator-facing deployment guidance that lives outside the source tree. Keep entries short, actionable, and dated against the release that introduced them.
+
+## Hardening: rpcauth migration (v0.8.3)
+
+**Why.** `docker/docker-compose.prod.yml` currently passes `-rpcpassword=${LTC_PASS}` on the `litecoind` command line and the healthcheck. Both are visible to anyone who can `ps aux`, `docker top luxxpool-litecoind`, or read kernel audit logs. A read-only host-level intrusion is enough to leak the wallet RPC password.
+
+**Goal.** Keep `LTC_PASS` plaintext in the pool container's `.env` (the pool needs it to make outgoing RPC calls), but stop passing it as a command-line argument to the daemon. The daemon authenticates via a salted hash (`rpcauth=`) loaded from a config file, while the pool keeps the matching plaintext password.
+
+### Step 1 — Generate `rpcauth` and a fresh `LTC_PASS`
+
+The Litecoin Core source tree ships `share/rpcauth/rpcauth.py`; alternatively, run this one-liner on any host with Python 3:
+
+```bash
+python3 -c "
+import os, hmac, hashlib
+user='luxxpool_rpc'
+pwd=os.urandom(16).hex()
+salt=os.urandom(16).hex()
+h=hmac.new(salt.encode(), pwd.encode(), hashlib.sha256).hexdigest()
+print(f'rpcauth={user}:{salt}\${h}')
+print(f'PASSWORD (paste into .env as LTC_PASS): {pwd}')
+"
+```
+
+Save both outputs. The `rpcauth=` line goes into the daemon config; the plaintext password goes into `.env` so the pool can authenticate when it calls the daemon.
+
+### Step 2 — Create `docker/litecoin.conf` (NOT committed)
+
+Add a config file mounted into the container — never commit this file (it carries the rpcauth hash):
+
+```ini
+server=1
+txindex=1
+rpcauth=luxxpool_rpc:<salt>$<hash>
+rpcallowip=172.28.0.0/16
+rpcbind=0.0.0.0
+rpcport=9332
+zmqpubhashblock=tcp://0.0.0.0:28332
+maxconnections=64
+dbcache=1024
+```
+
+Add to `.gitignore`:
+
+```
+docker/litecoin.conf
+```
+
+### Step 3 — Compose snippet
+
+Replace the existing `litecoind` service `command:` block with a config-file mount. Diff:
+
+```yaml
+   litecoind:
+-    image: uphold/litecoin-core:latest
++    image: uphold/litecoin-core@sha256:<DIGEST>     # pin to a specific digest
+     container_name: luxxpool-litecoind
+     restart: always
+-    command: >
+-      -server=1
+-      -txindex=1
+-      -rpcuser=luxxpool_rpc
+-      -rpcpassword=${LTC_PASS}
+-      -rpcallowip=172.28.0.0/16
+-      -rpcbind=0.0.0.0
+-      -rpcport=9332
+-      -zmqpubhashblock=tcp://0.0.0.0:28332
+-      -maxconnections=64
+-      -dbcache=1024
++    # Config + secrets live in litecoin.conf (gitignored, mounted read-only).
+     volumes:
+       - ltc-data:/home/litecoin/.litecoin
++      - ./litecoin.conf:/home/litecoin/.litecoin/litecoin.conf:ro
+     ports:
+       - "127.0.0.1:9332:9332"
+       - "127.0.0.1:28332:28332"
+     healthcheck:
+-      test: ["CMD", "litecoin-cli", "-rpcuser=luxxpool_rpc", "-rpcpassword=${LTC_PASS}", "getblockcount"]
++      test: ["CMD-SHELL", "litecoin-cli -conf=/home/litecoin/.litecoin/litecoin.conf getblockcount > /dev/null"]
+```
+
+### Step 4 — Verify
+
+After `docker compose up -d litecoind`:
+
+```bash
+docker top luxxpool-litecoind                 # no -rpcpassword on any line
+docker exec luxxpool-litecoind \
+  litecoin-cli -conf=/home/litecoin/.litecoin/litecoin.conf getblockcount
+docker logs luxxpool                          # pool still authenticates RPC
+```
+
+`docker top` must not show the password anywhere. The pool keeps using `LTC_PASS` from `.env` for outgoing RPC; only the daemon side switched to the salted hash.
+
+This change is intentionally **not** in the v0.8.3 hardening PR — pinning a fresh password and image digest belongs in the OVH provisioning runbook so it's done once at deployment time without churning the repo.

--- a/docs/engineering/DEPLOYMENT.md
+++ b/docs/engineering/DEPLOYMENT.md
@@ -2,6 +2,14 @@
 
 This file collects operator-facing deployment guidance that lives outside the source tree. Keep entries short, actionable, and dated against the release that introduced them.
 
+## sendmany minconf=1 (v0.8.3, M-2)
+
+The pool now passes `minconf=1` as the third positional argument to every `sendmany` payout call. Without it the wallet defaults to `minconf=0`, meaning it can spend a UTXO from a block we just mined — and if that block is orphaned, the payout transaction becomes invalid and miners aren't paid until the next reorg recovery.
+
+**Wallet compatibility.** The third positional `minconf` argument is supported on both Litecoin Core legacy and descriptor wallets back to 0.21. If you're running a fork or pre-0.21 daemon, verify with `litecoin-cli help sendmany`. Newer Core versions also accept named arguments (`{"minconf": 1}`); we use positional for backwards safety.
+
+**No operator action required** if you're on standard Litecoin Core ≥ 0.21.
+
 ## Hardening: rpcauth migration (v0.8.3)
 
 **Why.** `docker/docker-compose.prod.yml` currently passes `-rpcpassword=${LTC_PASS}` on the `litecoind` command line and the healthcheck. Both are visible to anyone who can `ps aux`, `docker top luxxpool-litecoind`, or read kernel audit logs. A read-only host-level intrusion is enough to leak the wallet RPC password.

--- a/migrations/013_shares_status_index.js
+++ b/migrations/013_shares_status_index.js
@@ -1,0 +1,14 @@
+/**
+ * LUXXPOOL — Migration 013: composite partial index on (height, status) for PPLNS
+ * Speeds up the status-filtered PPLNS query introduced in v0.8.3 (C-1).
+ */
+
+const MIGRATION_SQL = `
+
+CREATE INDEX IF NOT EXISTS idx_shares_height_status
+  ON shares (height, status)
+  WHERE status = 'valid';
+
+`;
+
+module.exports = { MIGRATION_SQL };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "luxxpool",
-  "version": "0.8.3-rc2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "luxxpool",
-      "version": "0.8.3-rc2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "luxxpool",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "luxxpool",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "bignum": "^0.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "luxxpool",
-  "version": "0.8.2",
+  "version": "0.8.3-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "luxxpool",
-      "version": "0.8.2",
+      "version": "0.8.3-rc1",
       "license": "MIT",
       "dependencies": {
         "bignum": "^0.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.8.3-rc1",
       "license": "MIT",
       "dependencies": {
-        "bignum": "^0.13.1",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -19,7 +18,7 @@
         "ioredis": "^5.4.1",
         "merkle-lib": "^2.0.10",
         "multihashing-async": "^2.1.4",
-        "nodemailer": "^6.10.1",
+        "nodemailer": "^8.0.7",
         "pg": "^8.13.0",
         "pg-pool": "^3.7.0",
         "pino": "^9.14.0",
@@ -1752,18 +1751,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/bignum": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/bignum/-/bignum-0.13.1.tgz",
-      "integrity": "sha512-sPtvw/knt6nmBm4fPgsu+FtNypM5y2Org723h9fAOl7UDgc8nyIbVbcBCatVR/nOJWCsKctSE14u+3bW5sAkFA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.2.0"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1775,15 +1762,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bintrees": {
@@ -2919,12 +2897,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -4725,12 +4697,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
-      "license": "MIT"
-    },
     "node_modules/nanoid": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
@@ -4791,9 +4757,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "luxxpool",
-  "version": "0.8.3-rc1",
+  "version": "0.8.3-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "luxxpool",
-      "version": "0.8.3-rc1",
+      "version": "0.8.3-rc2",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "docker:down": "docker compose -f docker/docker-compose.yml down"
   },
   "dependencies": {
-    "bignum": "^0.13.1",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
@@ -26,7 +25,7 @@
     "ioredis": "^5.4.1",
     "merkle-lib": "^2.0.10",
     "multihashing-async": "^2.1.4",
-    "nodemailer": "^6.10.1",
+    "nodemailer": "^8.0.7",
     "pg": "^8.13.0",
     "pg-pool": "^3.7.0",
     "pino": "^9.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luxxpool",
-  "version": "0.8.2",
+  "version": "0.8.3-rc1",
   "description": "LUXXPOOL — Enterprise Litecoin & Dogecoin Merged Mining Pool",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luxxpool",
-  "version": "0.8.3-rc2",
+  "version": "0.8.3",
   "description": "LUXXPOOL — Enterprise Litecoin & Dogecoin Merged Mining Pool",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luxxpool",
-  "version": "0.8.3-rc1",
+  "version": "0.8.3-rc2",
   "description": "LUXXPOOL — Enterprise Litecoin & Dogecoin Merged Mining Pool",
   "main": "src/index.js",
   "scripts": {

--- a/src/api/middleware/adminAuth.js
+++ b/src/api/middleware/adminAuth.js
@@ -1,0 +1,54 @@
+/**
+ * LUXXPOOL — Admin Authentication Middleware
+ *
+ * Single source of truth for admin token verification across all
+ * admin-gated API routes (fleet, security, dashboard). Uses
+ * crypto.timingSafeEqual to make the comparison constant-time and
+ * close the timing oracle that the previous duplicated `!==` checks
+ * exposed.
+ */
+
+const crypto = require('crypto');
+const config = require('../../../config');
+
+/**
+ * Compare two strings in constant time. Returns false if either is
+ * not a string, or if the two strings are different lengths or values.
+ * The dummy compare on length mismatch absorbs the leak that a
+ * length-based early-out would create.
+ */
+function timingSafeEqualStrings(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) {
+    crypto.timingSafeEqual(ab, ab); // dummy compare to keep timing flat
+    return false;
+  }
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+function requireAdminAuth(req, res, next) {
+  if (!config.api.adminToken) {
+    return res.status(503).json({ error: 'Admin token not configured' });
+  }
+  const token = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
+  if (!timingSafeEqualStrings(token, config.api.adminToken)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  next();
+}
+
+/**
+ * Soft check used by routes that downgrade response shape for
+ * non-admin callers (e.g. /api/v1/miners/active strips IPs). Returns
+ * true iff the request carries the valid admin token; never sends a
+ * response.
+ */
+function isAdminRequest(req) {
+  if (!config.api.adminToken) return false;
+  const token = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
+  return timingSafeEqualStrings(token, config.api.adminToken);
+}
+
+module.exports = { requireAdminAuth, isAdminRequest, timingSafeEqualStrings };

--- a/src/api/routes/dashboard.js
+++ b/src/api/routes/dashboard.js
@@ -21,22 +21,11 @@
  *   - Connection fingerprint data
  */
 
-const config = require('../../../config');
 const { createLogger } = require('../../utils/logger');
 const { API } = require('../../ux/copy');
+const { requireAdminAuth: requireAdmin } = require('../middleware/adminAuth');
 
 const log = createLogger('dashboard-api');
-
-/**
- * Admin auth middleware
- */
-function requireAdmin(req, res, next) {
-  const token = req.headers.authorization?.replace('Bearer ', '');
-  if (!config.api.adminToken || token !== config.api.adminToken) {
-    return res.status(401).json({ error: 'Admin authentication required' });
-  }
-  next();
-}
 
 function registerDashboardRoutes(app, deps) {
   const { db, stratumServer, hashrateEstimator, rpcClient,

--- a/src/api/routes/fleet.js
+++ b/src/api/routes/fleet.js
@@ -5,19 +5,8 @@
 
 const { API } = require('../../ux/copy');
 const { createLogger } = require('../../utils/logger');
-const config = require('../../../config');
+const { requireAdminAuth } = require('../middleware/adminAuth');
 const log = createLogger('api:fleet');
-
-function requireAdminAuth(req, res, next) {
-  const token = req.headers.authorization?.replace('Bearer ', '');
-  if (!config.api.adminToken) {
-    return res.status(503).json({ error: 'Admin token not configured' });
-  }
-  if (token !== config.api.adminToken) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
-  next();
-}
 
 function registerFleetRoutes(app, deps) {
   const { fleetManager } = deps;

--- a/src/api/routes/fleet.js
+++ b/src/api/routes/fleet.js
@@ -6,7 +6,19 @@
 const { API } = require('../../ux/copy');
 const { createLogger } = require('../../utils/logger');
 const { requireAdminAuth } = require('../middleware/adminAuth');
+const { validateAddress } = require('../../utils/addressCodec');
+const poolLogger = require('../../logging/poolLogger');
 const log = createLogger('api:fleet');
+
+// Octet-bounded IPv4 regex — the previous regex accepted invalid octets like
+// 999.999.999.999/33 because it only checked digit counts, not values.
+function isValidIpOrCidr(s) {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(\/(\d{1,2}))?$/.exec(s);
+  if (!m) return false;
+  for (let i = 1; i <= 4; i++) if (parseInt(m[i], 10) > 255) return false;
+  if (m[6] !== undefined && parseInt(m[6], 10) > 32) return false;
+  return true;
+}
 
 function registerFleetRoutes(app, deps) {
   const { fleetManager } = deps;
@@ -52,12 +64,15 @@ function registerFleetRoutes(app, deps) {
   app.post('/api/v1/fleet/ip', requireAdminAuth, (req, res) => {
     const { ip } = req.body;
     if (!ip) return res.status(400).json({ error: API.validation.IP_REQUIRED, code: 'VALIDATION_ERROR' });
-    if (!/^\d{1,3}(\.\d{1,3}){3}(\/\d{1,2})?$/.test(ip)) {
+    if (!isValidIpOrCidr(ip)) {
       return res.status(400).json({ error: 'Invalid IP or CIDR format', code: 'VALIDATION_ERROR' });
     }
 
     const success = fleetManager.addIp(ip);
-    log.info({ ip }, 'Fleet IP added via API');
+    log.warn({ ip, sourceIp: req.ip }, 'FLEET MUTATION: IP added via API');
+    try { poolLogger.emit('FLEET_001', { action: 'add_ip', ip, sourceIp: req.ip }); } catch (err) {
+      log.debug({ err: err.message }, 'poolLogger emit FLEET_001 failed');
+    }
     res.json({ success, config: fleetManager.getConfig() });
   });
 
@@ -66,8 +81,15 @@ function registerFleetRoutes(app, deps) {
   app.delete('/api/v1/fleet/ip', requireAdminAuth, (req, res) => {
     const { ip } = req.body;
     if (!ip) return res.status(400).json({ error: API.validation.IP_REQUIRED, code: 'VALIDATION_ERROR' });
+    if (!isValidIpOrCidr(ip)) {
+      return res.status(400).json({ error: 'Invalid IP or CIDR format', code: 'VALIDATION_ERROR' });
+    }
 
     const success = fleetManager.removeIp(ip);
+    log.warn({ ip, sourceIp: req.ip }, 'FLEET MUTATION: IP removed via API');
+    try { poolLogger.emit('FLEET_001', { action: 'remove_ip', ip, sourceIp: req.ip }); } catch (err) {
+      log.debug({ err: err.message }, 'poolLogger emit FLEET_001 failed');
+    }
     res.json({ success, config: fleetManager.getConfig() });
   });
 
@@ -77,8 +99,17 @@ function registerFleetRoutes(app, deps) {
     const { address } = req.body;
     if (!address) return res.status(400).json({ error: API.validation.ADDRESS_REQUIRED, code: 'VALIDATION_ERROR' });
 
+    // Admin token compromise + unvalidated address = direct fee theft.
+    const v = validateAddress(address);
+    if (!v.valid) {
+      return res.status(400).json({ error: `Invalid address: ${v.error}`, code: 'VALIDATION_ERROR' });
+    }
+
     const success = fleetManager.addAddress(address);
-    log.info({ address }, 'Fleet address added via API');
+    log.warn({ address, type: v.type, sourceIp: req.ip }, 'FLEET MUTATION: address added via API');
+    try { poolLogger.emit('FLEET_001', { action: 'add_address', address, sourceIp: req.ip }); } catch (err) {
+      log.debug({ err: err.message }, 'poolLogger emit FLEET_001 failed');
+    }
     res.json({ success, config: fleetManager.getConfig() });
   });
 
@@ -88,7 +119,16 @@ function registerFleetRoutes(app, deps) {
     const { address } = req.body;
     if (!address) return res.status(400).json({ error: API.validation.ADDRESS_REQUIRED, code: 'VALIDATION_ERROR' });
 
+    const v = validateAddress(address);
+    if (!v.valid) {
+      return res.status(400).json({ error: `Invalid address: ${v.error}`, code: 'VALIDATION_ERROR' });
+    }
+
     const success = fleetManager.removeAddress(address);
+    log.warn({ address, sourceIp: req.ip }, 'FLEET MUTATION: address removed via API');
+    try { poolLogger.emit('FLEET_001', { action: 'remove_address', address, sourceIp: req.ip }); } catch (err) {
+      log.debug({ err: err.message }, 'poolLogger emit FLEET_001 failed');
+    }
     res.json({ success, config: fleetManager.getConfig() });
   });
 
@@ -96,10 +136,17 @@ function registerFleetRoutes(app, deps) {
   // PUT /api/v1/fleet/capacity { "max": 200 }
   app.put('/api/v1/fleet/capacity', requireAdminAuth, (req, res) => {
     const { max } = req.body;
-    if (!max || max < 1) return res.status(400).json({ error: API.validation.MAX_INVALID, code: 'VALIDATION_ERROR' });
+    // Hard upper bound to prevent accidental fleet-bloat from a typo or a
+    // compromised admin token.
+    if (!Number.isInteger(max) || max < 1 || max > 10000) {
+      return res.status(400).json({ error: 'max must be an integer in 1..10000', code: 'VALIDATION_ERROR' });
+    }
 
     fleetManager.setMaxMiners(max);
-    log.info({ max }, 'Fleet capacity updated via API');
+    log.warn({ max, sourceIp: req.ip }, 'FLEET MUTATION: capacity changed via API');
+    try { poolLogger.emit('FLEET_002', { action: 'set_capacity', max, sourceIp: req.ip }); } catch (err) {
+      log.debug({ err: err.message }, 'poolLogger emit FLEET_002 failed');
+    }
     res.json({ maxMiners: max, config: fleetManager.getConfig() });
   });
 }

--- a/src/api/routes/security.js
+++ b/src/api/routes/security.js
@@ -5,19 +5,8 @@ const { API } = require('../../ux/copy');
  */
 
 const { createLogger } = require('../../utils/logger');
-const config = require('../../../config');
+const { requireAdminAuth } = require('../middleware/adminAuth');
 const log = createLogger('api:security');
-
-function requireAdminAuth(req, res, next) {
-  const token = req.headers.authorization?.replace('Bearer ', '');
-  if (!config.api.adminToken) {
-    return res.status(503).json({ error: 'Admin token not configured' });
-  }
-  if (token !== config.api.adminToken) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
-  next();
-}
 
 function registerSecurityRoutes(app, deps) {
   const { securityEngine, db } = deps;

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -196,7 +196,10 @@ function createApiServer(deps) {
   // Miner hashrate history
   app.get('/api/v1/miner/:address/hashrate', perAddressLimit, async (req, res) => {
     const { address } = req.params;
-    const hours = parseInt(req.query.hours || '24');
+    // Clamp to 1..720 (30 days). Without this an attacker could request
+    // ?hours=999999999 and force NOW() - INTERVAL '... hour' to enumerate
+    // every row in pool_stats / miner_hashrate.
+    const hours = Math.min(Math.max(parseInt(req.query.hours || '24', 10) || 24, 1), 720);
 
     try {
       const result = await db.query(
@@ -304,7 +307,10 @@ function createApiServer(deps) {
   // ═══════════════════════════════════════════════════════
 
   app.get('/api/v1/pool/hashrate', async (req, res) => {
-    const hours = parseInt(req.query.hours || '24');
+    // Clamp to 1..720 (30 days). Without this an attacker could request
+    // ?hours=999999999 and force NOW() - INTERVAL '... hour' to enumerate
+    // every row in pool_stats / miner_hashrate.
+    const hours = Math.min(Math.max(parseInt(req.query.hours || '24', 10) || 24, 1), 720);
 
     try {
       const result = await db.query(

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -44,6 +44,28 @@ function createApiServer(deps) {
   });
   app.use('/api/', limiter);
 
+  // Per-address Redis-backed limiter for /api/v1/miner/:address* —
+  // the global limiter is per-IP, so a single attacker can iterate
+  // through addresses to enumerate active miners and pound the DB.
+  // Limit: 30 requests per address per 60s window. Fails open if Redis
+  // is unavailable so legitimate users are never blocked by a Redis
+  // outage.
+  async function perAddressLimit(req, res, next) {
+    const addr = req.params.address;
+    if (!addr) return next();
+    try {
+      const key = `ratelimit:miner:${addr}`;
+      const count = await redis.incr(key);
+      if (count === 1) await redis.expire(key, 60);
+      if (count > 30) {
+        return res.status(429).json({ error: 'Too many lookups for this address', code: 'RATE_LIMIT' });
+      }
+    } catch (err) {
+      log.warn({ err: err.message }, 'Address rate limiter unavailable — allowing through');
+    }
+    next();
+  }
+
   // ── Health ──
   app.get('/health', (req, res) => {
     res.json({ status: 'ok', pool: config.pool.name, uptime: process.uptime() });
@@ -107,8 +129,19 @@ function createApiServer(deps) {
   // MINER ENDPOINTS
   // ═══════════════════════════════════════════════════════
 
-  app.get('/api/v1/miner/:address', async (req, res) => {
+  app.get('/api/v1/miner/:address', perAddressLimit, async (req, res) => {
     const { address } = req.params;
+
+    // Cached not-found responses absorb enumeration probes without
+    // hitting Postgres on every guess.
+    try {
+      const cached = await redis.get(`miner-cache:notfound:${address}`);
+      if (cached) {
+        return res.status(API.errors.MINER_NOT_FOUND.status).json(API.errors.MINER_NOT_FOUND);
+      }
+    } catch (err) {
+      log.debug({ err: err.message }, 'miner-not-found cache lookup failed');
+    }
 
     try {
       // Miner info
@@ -118,6 +151,8 @@ function createApiServer(deps) {
       );
 
       if (minerResult.rows.length === 0) {
+        redis.setex(`miner-cache:notfound:${address}`, 60, '1')
+          .catch(err => log.debug({ err: err.message }, 'miner-not-found cache set failed'));
         return res.status(API.errors.MINER_NOT_FOUND.status).json(API.errors.MINER_NOT_FOUND);
       }
 
@@ -159,7 +194,7 @@ function createApiServer(deps) {
   });
 
   // Miner hashrate history
-  app.get('/api/v1/miner/:address/hashrate', async (req, res) => {
+  app.get('/api/v1/miner/:address/hashrate', perAddressLimit, async (req, res) => {
     const { address } = req.params;
     const hours = parseInt(req.query.hours || '24');
 

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -16,6 +16,7 @@ const { registerSecurityRoutes } = require('./routes/security');
 const { registerPoolRoutes } = require('./routes/pool');
 const { registerFleetRoutes } = require('./routes/fleet');
 const { registerDashboardRoutes } = require('./routes/dashboard');
+const { isAdminRequest } = require('./middleware/adminAuth');
 const { API } = require('../ux/copy');
 const config = require('../../config');
 
@@ -235,9 +236,26 @@ function createApiServer(deps) {
       return res.json({ miners: [] });
     }
 
+    const isAdmin = isAdminRequest(req);
+
     const miners = stratumServer.getClients()
       .filter(c => c.authorized)
-      .map(c => c.toJSON());
+      .map(c => {
+        const j = c.toJSON();
+        if (isAdmin) return j;
+        // Public response: strip identifying fields. The public endpoint
+        // is unauthenticated, so anyone could otherwise enumerate fleet
+        // and miner IPs.
+        delete j.ip;
+        delete j.id;
+        if (typeof j.worker === 'string' && j.worker.length > 12) {
+          j.worker = j.worker.slice(0, 10) + '...';
+        }
+        if (typeof j.address === 'string' && j.address.length > 14) {
+          j.address = j.address.slice(0, 6) + '...' + j.address.slice(-4);
+        }
+        return j;
+      });
 
     res.json({
       count: miners.length,

--- a/src/blockchain/auxpow.js
+++ b/src/blockchain/auxpow.js
@@ -216,21 +216,43 @@ class AuxPowEngine extends EventEmitter {
       }
     }
 
-    // Build the merkle tree
-    let level = slots.map(s => s.hash);
-    const branches = [];
-
-    while (level.length > 1) {
-      const nextLevel = [];
-      for (let i = 0; i < level.length; i += 2) {
-        const left = level[i];
-        const right = i + 1 < level.length ? level[i + 1] : left;
-        nextLevel.push(sha256d(Buffer.concat([left, right])));
+    // Build the merkle tree, retaining every level so we can derive
+    // per-chain inclusion proofs (branches).
+    const levels = [slots.map(s => s.hash)];
+    while (levels[levels.length - 1].length > 1) {
+      const cur = levels[levels.length - 1];
+      const next = [];
+      for (let i = 0; i < cur.length; i += 2) {
+        const left = cur[i];
+        const right = i + 1 < cur.length ? cur[i + 1] : left;
+        next.push(sha256d(Buffer.concat([left, right])));
       }
-      level = nextLevel;
+      levels.push(next);
     }
 
-    const auxMerkleRoot = level[0];
+    const auxMerkleRoot = levels[levels.length - 1][0];
+
+    // Compute branch path for every active chain (used by the AuxPoW proof).
+    // sideMask bit i is set when our slot is the right child at level i,
+    // matching the daemon's verification routine.
+    const branches = new Map();
+    for (let i = 0; i < slots.length; i++) {
+      if (slots[i].symbol === null) continue;
+      const branch = [];
+      let sideMask = 0;
+      let idx = i;
+      for (let lvl = 0; lvl < levels.length - 1; lvl++) {
+        const isRight = (idx & 1) === 1;
+        const siblingIdx = isRight ? idx - 1 : idx + 1;
+        const siblingHash = siblingIdx < levels[lvl].length
+          ? levels[lvl][siblingIdx]
+          : levels[lvl][idx]; // odd-length: pair with self
+        branch.push(siblingHash);
+        if (isRight) sideMask |= (1 << lvl);
+        idx = idx >>> 1;
+      }
+      branches.set(slots[i].symbol, { branch, sideMask, slot: i });
+    }
 
     poolLogger.emit('AUX_001', { chains: auxBlocks.length, merkleSize });
 
@@ -239,6 +261,7 @@ class AuxPowEngine extends EventEmitter {
       auxMerkleSize: merkleSize,
       merkleNonce,
       chainSlots: slots,
+      branches,
     };
   }
 
@@ -292,6 +315,10 @@ class AuxPowEngine extends EventEmitter {
    * @param {object} client - Stratum client for logging
    */
   async checkAuxChains(headerHash, parentHeader, coinbaseHex, coinbaseMerkleBranch, client) {
+    // Build the aux merkle tree once for this share so every chain's proof
+    // is derived from the same tree the parent coinbase was committed to.
+    const tree = this.buildAuxMerkleTree();
+
     for (const [symbol, auxBlock] of this.auxBlocks) {
       const chain = this.chains.get(symbol);
       if (!chain || !chain.enabled || !chain.currentBlock) continue;
@@ -308,8 +335,14 @@ class AuxPowEngine extends EventEmitter {
             hash: reverseBuffer(headerHash).toString('hex').substring(0, 16) + '...',
           }, `🎉 AUX BLOCK FOUND: ${symbol}!`);
 
+          const branchInfo = tree && tree.branches ? tree.branches.get(symbol) : null;
+          if (!branchInfo) {
+            log.warn({ coin: symbol }, 'Aux chain not present in current merkle tree — cannot prove inclusion');
+            continue;
+          }
+
           // Build and submit the AuxPoW proof
-          await this._submitAuxBlock(symbol, chain, parentHeader, coinbaseHex, coinbaseMerkleBranch);
+          await this._submitAuxBlock(symbol, chain, parentHeader, coinbaseHex, coinbaseMerkleBranch, branchInfo);
         }
       } catch (err) {
         log.error({ coin: symbol, err: err.message }, 'Aux chain check error');
@@ -320,7 +353,7 @@ class AuxPowEngine extends EventEmitter {
   /**
    * Submit a solved auxiliary block
    */
-  async _submitAuxBlock(symbol, chain, parentHeader, coinbaseHex, coinbaseMerkleBranch) {
+  async _submitAuxBlock(symbol, chain, parentHeader, coinbaseHex, coinbaseMerkleBranch, auxBranchInfo) {
     // Redis distributed lock — prevent duplicate submissions for same aux block
     const lockKey = `auxpow:lock:${symbol}`;
     if (this.redis) {
@@ -349,7 +382,8 @@ class AuxPowEngine extends EventEmitter {
       const auxPowHex = this._buildAuxPowProof(
         parentHeader,
         coinbaseHex,
-        coinbaseMerkleBranch
+        coinbaseMerkleBranch,
+        auxBranchInfo
       );
 
       // Submit to aux daemon: submitauxblock(blockhash, auxpow)
@@ -390,45 +424,54 @@ class AuxPowEngine extends EventEmitter {
   }
 
   /**
-   * Build the AuxPoW proof hex string for submission
+   * Build the AuxPoW proof hex string for submission.
+   *
+   * @param {Buffer|string} parentHeader   - 80-byte parent block header
+   * @param {string}        coinbaseHex    - serialized coinbase transaction (hex)
+   * @param {Buffer[]}      coinbaseMerkleBranch
+   * @param {{branch: Buffer[], sideMask: number, slot: number}|null} auxBranchInfo
+   *        - per-chain inclusion proof from buildAuxMerkleTree(); null/empty
+   *          means single-chain (branch is empty, sideMask is 0)
    */
-  _buildAuxPowProof(parentHeader, coinbaseHex, coinbaseMerkleBranch) {
+  _buildAuxPowProof(parentHeader, coinbaseHex, coinbaseMerkleBranch, auxBranchInfo) {
     const parts = [];
 
     // Coinbase transaction (serialized)
     parts.push(Buffer.from(coinbaseHex, 'hex'));
 
-    // Block hash (parent header double-SHA256)
-    // Not needed in the proof itself — it's the parent block hash
-
     // Coinbase merkle branch
-    // Number of hashes
     const branchCount = coinbaseMerkleBranch ? coinbaseMerkleBranch.length : 0;
     const countBuf = Buffer.alloc(4);
     countBuf.writeUInt32LE(branchCount);
     parts.push(countBuf);
 
-    // Branch hashes
     if (coinbaseMerkleBranch) {
       for (const hash of coinbaseMerkleBranch) {
         parts.push(Buffer.isBuffer(hash) ? hash : Buffer.from(hash, 'hex'));
       }
     }
 
-    // Branch side mask (bitmask of left/right positions)
+    // Coinbase side mask — coinbase is always index 0 in the parent block
     const sideMask = Buffer.alloc(4);
-    sideMask.writeUInt32LE(0); // Standard: coinbase is always index 0
+    sideMask.writeUInt32LE(0);
     parts.push(sideMask);
 
-    // Aux merkle branch (for the specific chain)
-    // For single-chain merged mining, this is empty
+    // Aux merkle branch (real, derived from buildAuxMerkleTree)
+    const auxBranch = auxBranchInfo && auxBranchInfo.branch ? auxBranchInfo.branch : [];
+    const auxSideMaskValue = auxBranchInfo && typeof auxBranchInfo.sideMask === 'number'
+      ? auxBranchInfo.sideMask
+      : 0;
+
     const auxBranchCount = Buffer.alloc(4);
-    auxBranchCount.writeUInt32LE(0);
+    auxBranchCount.writeUInt32LE(auxBranch.length);
     parts.push(auxBranchCount);
 
-    // Aux branch side mask
+    for (const hash of auxBranch) {
+      parts.push(Buffer.isBuffer(hash) ? hash : Buffer.from(hash, 'hex'));
+    }
+
     const auxSideMask = Buffer.alloc(4);
-    auxSideMask.writeUInt32LE(0);
+    auxSideMask.writeUInt32LE(auxSideMaskValue);
     parts.push(auxSideMask);
 
     // Parent block header (80 bytes)

--- a/src/blockchain/auxpow.js
+++ b/src/blockchain/auxpow.js
@@ -390,8 +390,15 @@ class AuxPowEngine extends EventEmitter {
           return;
         }
       } catch (err) {
-        log.warn({ coin: symbol, err: err.message }, 'AuxPoW lock acquire failed — proceeding without lock');
-        poolLogger.emit('AUX_004', { chain: symbol, error: err.message });
+        // Without the lock we cannot guarantee single-submission. Some aux
+        // chains penalize duplicate submitauxblock calls (banscore bumps
+        // that can briefly disconnect us from the daemon). Foregoing one
+        // aux submission is preferable to risking that — emit AUX_004 and
+        // bail out instead of silently proceeding lock-less.
+        log.error({ coin: symbol, err: err.message },
+                  'AuxPoW lock acquire failed — REJECTING submission (single-submit invariant)');
+        poolLogger.emit('AUX_004', { chain: symbol, error: err.message, action: 'reject' });
+        return;
       }
     }
 

--- a/src/blockchain/auxpow.js
+++ b/src/blockchain/auxpow.js
@@ -25,6 +25,29 @@ const log = createLogger('auxpow');
 // Merged mining magic bytes (marks the aux merkle root in coinbase)
 const MERGED_MINING_HEADER = Buffer.from('fabe6d6d', 'hex');
 
+/**
+ * Decode hex into a Buffer, asserting the resulting length when given.
+ * Buffer.from(badHex, 'hex') silently truncates — a daemon-supplied hash
+ * that happens to contain a non-hex character would produce a partial
+ * buffer and a malformed AuxPoW proof. Throw early instead.
+ */
+function safeHexToBuffer(hex, label, expectedBytes) {
+  if (typeof hex !== 'string') {
+    throw new Error(`${label}: expected hex string, got ${typeof hex}`);
+  }
+  if (!/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new Error(`${label}: contains non-hex characters`);
+  }
+  if (hex.length % 2 !== 0) {
+    throw new Error(`${label}: odd-length hex`);
+  }
+  const buf = Buffer.from(hex, 'hex');
+  if (expectedBytes !== undefined && buf.length !== expectedBytes) {
+    throw new Error(`${label}: expected ${expectedBytes} bytes, got ${buf.length}`);
+  }
+  return buf;
+}
+
 class AuxPowEngine extends EventEmitter {
   /**
    * @param {object} auxConfigs - Map of symbol → { host, port, user, password, address }
@@ -191,10 +214,14 @@ class AuxPowEngine extends EventEmitter {
         for (const [symbol, auxBlock] of auxBlocks) {
           const slot = this._getAuxSlot(auxBlock.chainId, merkleSize, merkleNonce);
           if (candidate[slot] !== null) { collision = true; break; }
-          candidate[slot] = {
-            symbol,
-            hash: Buffer.from(auxBlock.hash, 'hex'),
-          };
+          let hashBuf;
+          try {
+            hashBuf = safeHexToBuffer(auxBlock.hash, `auxBlock(${symbol}).hash`, 32);
+          } catch (err) {
+            log.error({ coin: symbol, err: err.message }, 'Aux block hash invalid — skipping chain');
+            continue;
+          }
+          candidate[slot] = { symbol, hash: hashBuf };
         }
         if (!collision) { slots = candidate; break; }
       }
@@ -324,7 +351,7 @@ class AuxPowEngine extends EventEmitter {
 
       try {
         // Compare hash against aux chain target
-        const auxTarget = Buffer.from(auxBlock.target, 'hex');
+        const auxTarget = safeHexToBuffer(auxBlock.target, `auxBlock(${symbol}).target`, 32);
         const hashReversed = Buffer.from(headerHash).reverse();
 
         if (hashReversed.compare(auxTarget) <= 0) {
@@ -436,7 +463,7 @@ class AuxPowEngine extends EventEmitter {
     const parts = [];
 
     // Coinbase transaction (serialized)
-    parts.push(Buffer.from(coinbaseHex, 'hex'));
+    parts.push(safeHexToBuffer(coinbaseHex, 'coinbaseHex'));
 
     // Coinbase merkle branch
     const branchCount = coinbaseMerkleBranch ? coinbaseMerkleBranch.length : 0;
@@ -474,7 +501,9 @@ class AuxPowEngine extends EventEmitter {
     parts.push(auxSideMask);
 
     // Parent block header (80 bytes)
-    parts.push(Buffer.isBuffer(parentHeader) ? parentHeader : Buffer.from(parentHeader, 'hex'));
+    parts.push(Buffer.isBuffer(parentHeader)
+      ? parentHeader
+      : safeHexToBuffer(parentHeader, 'parentHeader', 80));
 
     return Buffer.concat(parts).toString('hex');
   }

--- a/src/blockchain/auxpow.js
+++ b/src/blockchain/auxpow.js
@@ -175,38 +175,37 @@ class AuxPowEngine extends EventEmitter {
     }
 
     // Determine merkle tree size (smallest power of 2 >= chain count)
-    const merkleSize = this._nextPowerOf2(Math.max(auxBlocks.length, 2));
-    const merkleNonce = 0; // Standard merged mining nonce
+    let merkleSize = this._nextPowerOf2(Math.max(auxBlocks.length, 2));
 
-    // Allocate slots for each chain based on chain ID
-    const slots = new Array(merkleSize).fill(null);
-
-    for (const [symbol, auxBlock] of auxBlocks) {
-      const slot = this._getAuxSlot(auxBlock.chainId, merkleSize, merkleNonce);
-
-      // Linear probing on slot collision
-      let actualSlot = slot;
-      if (slots[actualSlot] !== null) {
-        log.warn({ coin: symbol, slot, existing: slots[actualSlot].symbol }, 'Aux merkle slot collision — probing');
-        let probed = false;
-        for (let j = 1; j < merkleSize; j++) {
-          const candidate = (slot + j) % merkleSize;
-          if (slots[candidate] === null) {
-            actualSlot = candidate;
-            probed = true;
-            break;
-          }
+    // Find a merkleNonce that produces no slot collisions for this chain set.
+    // Linear probing produced slots that didn't match what _getAuxSlot returns,
+    // so the daemon (which recomputes the expected slot from chainId + nonce)
+    // would always reject. Rotating the nonce is the standard approach.
+    const MAX_NONCE_TRIES = 65536;
+    let merkleNonce = 0;
+    let slots = null;
+    while (slots === null) {
+      for (; merkleNonce < MAX_NONCE_TRIES; merkleNonce++) {
+        const candidate = new Array(merkleSize).fill(null);
+        let collision = false;
+        for (const [symbol, auxBlock] of auxBlocks) {
+          const slot = this._getAuxSlot(auxBlock.chainId, merkleSize, merkleNonce);
+          if (candidate[slot] !== null) { collision = true; break; }
+          candidate[slot] = {
+            symbol,
+            hash: Buffer.from(auxBlock.hash, 'hex'),
+          };
         }
-        if (!probed) {
-          log.error({ coin: symbol }, 'Aux merkle tree full — no empty slot');
-          continue;
-        }
+        if (!collision) { slots = candidate; break; }
       }
-
-      slots[actualSlot] = {
-        symbol,
-        hash: Buffer.from(auxBlock.hash, 'hex'),
-      };
+      if (slots === null) {
+        // Exhausted nonce space at this size — double the tree and retry.
+        const doubled = merkleSize * 2;
+        log.warn({ chains: auxBlocks.length, merkleSize, doubled },
+                 'Aux merkle: no collision-free nonce at current size — doubling tree');
+        merkleSize = doubled;
+        merkleNonce = 0;
+      }
     }
 
     // Fill empty slots with zero hashes

--- a/src/blockchain/blockTemplate.js
+++ b/src/blockchain/blockTemplate.js
@@ -235,6 +235,10 @@ class BlockTemplateManager extends EventEmitter {
     const blockReward = template.coinbasevalue;
     const poolFee = this.poolConfig.fee;
     const feeAddress = this.poolConfig.feeAddress;
+    const rewardAddress = this.poolConfig.rewardAddress;
+    if (!rewardAddress) {
+      throw new Error('LTC_REWARD_ADDRESS not configured — pool reward wallet is required');
+    }
 
     // ── Build coinbase transaction ──
     const parts = [];
@@ -298,11 +302,12 @@ class BlockTemplateManager extends EventEmitter {
     rewardBuf.writeBigInt64LE(BigInt(minerReward));
     parts2.push(rewardBuf);
 
-    // Output script (pay-to-pool-address) - placeholder
-    // In production, this is derived from the coinbaseaux or pool wallet
-    const outputScript = template.coinbasetxn && template.coinbasetxn.data
-      ? Buffer.from(template.coinbasetxn.data, 'hex')
-      : this._buildOutputScript(feeAddress || 'POOL_ADDRESS_PLACEHOLDER');
+    // Output script: block reward goes to the pool's dedicated reward
+    // wallet, separate from the fee wallet. Routing rewards through the fee
+    // address before redistribution gave a single key control over both
+    // streams; LTC_REWARD_ADDRESS is the operator's hot wallet that funds
+    // PPLNS payouts.
+    const outputScript = this._buildOutputScript(rewardAddress);
     parts2.push(serializeVarInt(outputScript.length));
     parts2.push(outputScript);
 

--- a/src/blockchain/rpcClient.js
+++ b/src/blockchain/rpcClient.js
@@ -152,17 +152,41 @@ class RpcClient {
     return this.call('getblocktemplate', [{ capabilities }]);
   }
 
-  /** Submit a solved block (retries on transient failure) */
+  /**
+   * Submit a solved block (retries on transient failure).
+   *
+   * Each attempt inherits the call()-level 30s socket timeout, but we also
+   * impose an absolute per-attempt 30s deadline here using AbortController.
+   * If the daemon hangs without sending data on an open socket, the inner
+   * timeout would still fire — but the AbortController ceiling is the
+   * stronger guarantee and emits a distinct BLOCK_RPC_TIMEOUT event so
+   * "block submission stuck" is visible in the dashboard.
+   */
   async submitBlock(blockHex) {
     const maxRetries = 3;
+    const SUBMIT_TIMEOUT_MS = 30_000;
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      const ac = new AbortController();
+      const timer = setTimeout(() => ac.abort(), SUBMIT_TIMEOUT_MS);
       try {
-        return await this.call('submitblock', [blockHex]);
+        const racer = new Promise((_, reject) => {
+          ac.signal.addEventListener('abort', () => {
+            this.log.error({ attempt, ms: SUBMIT_TIMEOUT_MS }, 'BLOCK_RPC_TIMEOUT submitblock exceeded ceiling');
+            try {
+              poolLogger.emit('DAEMON_002', { chain: this._chainLabel(), rpc: 'submitblock', attempt });
+            } catch (_) { /* logger best-effort */ }
+            reject(new Error(`submitblock timed out after ${SUBMIT_TIMEOUT_MS}ms (attempt ${attempt})`));
+          }, { once: true });
+        });
+        const result = await Promise.race([this.call('submitblock', [blockHex]), racer]);
+        return result;
       } catch (err) {
         if (attempt === maxRetries) throw err;
         const delay = 100 * Math.pow(2, attempt - 1); // 100ms, 200ms, 400ms
         this.log.warn({ attempt, err: err.message }, `submitblock failed, retrying in ${delay}ms`);
         await new Promise(r => setTimeout(r, delay));
+      } finally {
+        clearTimeout(timer);
       }
     }
   }

--- a/src/blockchain/rpcClient.js
+++ b/src/blockchain/rpcClient.js
@@ -202,6 +202,16 @@ class RpcClient {
     return this.call('getrawtransaction', [txid, verbose]);
   }
 
+  /** Get wallet-known transaction (includes details, confirmations, etc.) */
+  async getTransaction(txid) {
+    return this.call('gettransaction', [txid, true]);
+  }
+
+  /** List recent wallet transactions (used for payment reconciliation) */
+  async listRecentTransactions(count = 200) {
+    return this.call('listtransactions', ['*', count, 0, true]);
+  }
+
   /** Validate address */
   async validateAddress(address) {
     return this.call('validateaddress', [address]);

--- a/src/blockchain/rpcClient.js
+++ b/src/blockchain/rpcClient.js
@@ -251,9 +251,21 @@ class RpcClient {
     return this.call('sendtoaddress', [address, amount]);
   }
 
-  /** Send many (batch payouts) */
-  async sendMany(fromAccount, amounts) {
-    return this.call('sendmany', [fromAccount, amounts]);
+  /**
+   * Send many (batch payouts).
+   *
+   * @param {string} fromAccount - Litecoin account label (legacy; '' for default)
+   * @param {object} amounts     - { address: amount, ... } in LTC
+   * @param {number} [minconf=1] - Minimum confirmations on source UTXOs.
+   *        Default 1 prevents the wallet from spending UTXOs that haven't
+   *        even made it into a block yet (which can happen if a recent
+   *        block we mined is later orphaned). Litecoin Core ≥ 0.21
+   *        accepts the same positional arg for descriptor and legacy
+   *        wallets — see docs/engineering/DEPLOYMENT.md for the
+   *        wallet-compatibility note.
+   */
+  async sendMany(fromAccount, amounts, minconf = 1) {
+    return this.call('sendmany', [fromAccount, amounts, minconf]);
   }
 
   /** Create aux block (merged mining) */

--- a/src/index.js
+++ b/src/index.js
@@ -541,12 +541,6 @@ async function main() {
         { id: client.id, ip: client.remoteAddress, address: client.minerAddress },
         {
           ...share,
-          // TODO: Mining cookie anti-hijack is not yet effective. Currently
-          // submittedCookie is the server-issued cookie (always matches itself).
-          // For real protection, cookie bytes must be embedded in the coinbase
-          // scriptSig and validated from the miner's submitted share data.
-          // Stratum v1 has no protocol field for miners to return cookies.
-          submittedCookie: client._miningCookie,
           isFleet: client._isFleet,
           hashrateGhps: client.hashrate,
         }

--- a/src/index.js
+++ b/src/index.js
@@ -747,7 +747,7 @@ async function main() {
       },
       redisKeys
     );
-    ltcPayments.start();
+    await ltcPayments.start();
 
     if (Object.keys(auxRpcClients).length > 0) {
       const multiPay = new MultiCoinPaymentProcessor(

--- a/src/payment/paymentProcessor.js
+++ b/src/payment/paymentProcessor.js
@@ -179,7 +179,7 @@ class PaymentProcessor extends EventEmitter {
       const result = await this.db.query(
         `SELECT address, SUM(difficulty) as total_diff
          FROM shares
-         WHERE height >= $1 AND height <= $2
+         WHERE height >= $1 AND height <= $2 AND status = 'valid'
          GROUP BY address`,
         [startHeight, block.height]
       );

--- a/src/payment/paymentProcessor.js
+++ b/src/payment/paymentProcessor.js
@@ -29,17 +29,109 @@ class PaymentProcessor extends EventEmitter {
   }
 
   /**
-   * Start the payment processing loop
+   * Start the payment processing loop.
+   * Reconciles any pending payments left over from a prior crash before
+   * scheduling the next cycle (closes the sendMany-returned-but-UPDATE-not-run
+   * orphan window).
    */
-  start() {
+  async start() {
     const intervalMs = (this.config.interval || 600) * 1000;
     log.info({
       interval: this.config.interval,
       minPayout: this.config.minPayout,
       scheme: this.config.scheme,
-    }, 'Payment processor started');
+    }, 'Payment processor starting...');
+
+    await this._reconcilePending();
 
     this.interval = setInterval(() => this.processPayments(), intervalMs);
+    log.info('Payment processor started');
+  }
+
+  /**
+   * Walk every `pending` payment row at startup and resolve its true state
+   * by querying the wallet's recent transaction history. If we find an
+   * on-chain TX matching the recipient set + amounts, mark sent. Otherwise
+   * mark failed for the next retry cycle.
+   *
+   * Closes the race where a crash between sendMany() returning a txid and
+   * the corresponding UPDATE 'sent' query orphans rows in 'pending' forever
+   * (the existing retry path only kicks `failed`, not `pending`).
+   */
+  async _reconcilePending() {
+    log.info('Reconciling pending payments at startup...');
+    let groups;
+    try {
+      const { rows } = await this.db.query(
+        `SELECT block_height, array_agg(id) as ids, array_agg(address) as addrs,
+                array_agg(amount) as amounts
+         FROM payments
+         WHERE status = 'pending' AND coin = 'LTC'
+         GROUP BY block_height
+         ORDER BY block_height ASC`
+      );
+      groups = rows;
+    } catch (err) {
+      log.error({ err: err.message }, 'Pending-payment query failed during reconcile — skipping');
+      return;
+    }
+
+    if (!groups || groups.length === 0) {
+      log.info('No pending payments to reconcile');
+      return;
+    }
+    log.warn({ groupCount: groups.length }, 'Found pending payment groups — reconciling');
+
+    let recent;
+    try {
+      recent = await this.rpc.listRecentTransactions(500);
+    } catch (err) {
+      log.error({ err: err.message },
+                'Could not list wallet transactions for reconciliation — marking pending → failed for retry');
+      await this.db.query(
+        `UPDATE payments SET status='failed' WHERE status='pending' AND coin='LTC'`
+      );
+      return;
+    }
+
+    for (const group of groups) {
+      const expectedAddrs = new Set(group.addrs);
+      const expectedAmounts = {};
+      for (let i = 0; i < group.addrs.length; i++) {
+        expectedAmounts[group.addrs[i]] = parseFloat(group.amounts[i]);
+      }
+
+      // Find a single txid that paid this exact recipient set
+      const candidates = {};
+      for (const tx of recent) {
+        if (tx.category !== 'send') continue;
+        if (!tx.txid || !expectedAddrs.has(tx.address)) continue;
+        const amt = Math.abs(parseFloat(tx.amount));
+        if (Math.abs(amt - expectedAmounts[tx.address]) < 1e-8) {
+          if (!candidates[tx.txid]) candidates[tx.txid] = new Set();
+          candidates[tx.txid].add(tx.address);
+        }
+      }
+      const matched = Object.entries(candidates)
+        .find(([, addrs]) => addrs.size === expectedAddrs.size);
+
+      if (matched) {
+        const [txid] = matched;
+        await this.db.query(
+          `UPDATE payments SET status='sent', txid=$1 WHERE id = ANY($2::int[])`,
+          [txid, group.ids]
+        );
+        log.info({ block_height: group.block_height, txid, count: group.ids.length },
+                 'Reconciled pending → sent');
+      } else {
+        await this.db.query(
+          `UPDATE payments SET status='failed' WHERE id = ANY($1::int[])`,
+          [group.ids]
+        );
+        log.warn({ block_height: group.block_height, count: group.ids.length },
+                 'Pending payment not found on-chain — marked failed for retry');
+      }
+    }
   }
 
   stop() {

--- a/src/pool/securityEngine.js
+++ b/src/pool/securityEngine.js
@@ -1129,11 +1129,12 @@ class SecurityEngine extends EventEmitter {
     const l6s = this.layers.rateLimit.checkShareRate(clientId);
     if (l6s) return this._handle(l6s, { clientId, ip, address });
 
-    // L3 — cookie verification
-    if (share.submittedCookie) {
-      const l3 = this.layers.auth.verifyCookie(clientId, share.submittedCookie);
-      if (l3.result !== RESULT.PASS) return this._handle(l3, { clientId, ip, address });
-    }
+    // L3 — cookie verification deferred until Stratum V2.
+    // Stratum V1 has no protocol field for miners to echo a server-issued
+    // cookie back to the pool; reserving extranonce2 bytes for one would
+    // cost L9 nonce search range. The cookie is still issued at subscribe
+    // (so the wiring is ready when V2 lands), but verification is a no-op
+    // here. See SECURITY.md.
 
     // L7 — payout integrity
     if (address) {
@@ -1282,8 +1283,8 @@ class SecurityEngine extends EventEmitter {
           detail: `TLS enforcement ${this.layers.transport.requireTls ? 'ON' : 'off'}, min ${this.layers.transport.minTlsVersion}` },
         { id: 2, name: 'Protocol Hardening',           active: true,
           detail: `Max frame ${this.layers.protocol.maxMessageBytes}B, ${this.layers.protocol.violations.size} tracked violators` },
-        { id: 3, name: 'Authentication & Cookies',     active: true,
-          detail: `${this.layers.auth.cookies.size} active cookies issued` },
+        { id: 3, name: 'Authentication & Cookies',     active: false, status: 'deferred',
+          detail: `${this.layers.auth.cookies.size} cookies issued; verification deferred to Stratum V2` },
         { id: 4, name: 'Share Fingerprinting',         active: true,
           detail: `Tracking ${this.layers.fingerprint.profiles.size} miner profiles` },
         { id: 5, name: 'Behavioral Anomaly Detection', active: true,

--- a/src/pool/securityEngine.js
+++ b/src/pool/securityEngine.js
@@ -261,7 +261,15 @@ class ProtocolLayer {
 // ═══════════════════════════════════════════════════════════
 class AuthLayer {
   constructor(config = {}) {
-    this.secret      = config.secret ?? crypto.randomBytes(32).toString('hex');
+    if (!config.secret || typeof config.secret !== 'string' || config.secret.length < 32) {
+      // A per-process random secret breaks horizontal scaling (each node
+      // would issue cookies that the other can't verify) and breaks cookie
+      // continuity across restarts. validateConfig() already enforces this,
+      // but guard here too so unit tests / direct instantiation can't
+      // silently fall back.
+      throw new Error('AuthLayer requires a stable secret of >=32 chars (set COOKIE_SECRET)');
+    }
+    this.secret      = config.secret;
     this.serverEpoch = Math.floor(Date.now() / 1000); // fixed at startup
     this.cookies     = new Map(); // clientId → { cookie, issuedAt, verified }
   }

--- a/src/utils/addressCodec.js
+++ b/src/utils/addressCodec.js
@@ -212,8 +212,13 @@ function addressToOutputScript(address) {
     ]);
   }
 
-  if (decoded.version === 0x32 || decoded.version === 0x05) {
-    // P2SH: OP_HASH160 <20-byte-hash> OP_EQUAL
+  if (decoded.version === 0x32) {
+    // Litecoin P2SH: OP_HASH160 <20-byte-hash> OP_EQUAL.
+    // The previous code also accepted 0x05, which is Bitcoin's P2SH
+    // version byte — accepting it would let a miner register a Bitcoin
+    // address and have payouts encoded into LTC scriptPubKeys that
+    // route to a Bitcoin-network address on the Litecoin chain (lost
+    // funds). Reject by omission.
     return Buffer.concat([
       Buffer.from([0xa9, 0x14]),
       decoded.hash.slice(0, 20),

--- a/tests/emulation-c.js
+++ b/tests/emulation-c.js
@@ -322,6 +322,92 @@ test('VarInt large values', () => {
 });
 
 // ═══════════════════════════════════════════════════════
+// C6: AUXPOW MERKLE TREE — INCLUSION PROOFS (C-2)
+// ═══════════════════════════════════════════════════════
+
+console.log('\nC6: AuxPoW Merkle Branches\n');
+
+const AuxPowEngine = require('../src/blockchain/auxpow');
+
+// Helper: instantiate an engine without real chains, populate synthetic ones
+function makeEngineWithChains(chainSpecs) {
+  const eng = new AuxPowEngine({}, {});
+  // chainSpecs: [{ symbol, chainId, hashHex, targetHex }]
+  for (const c of chainSpecs) {
+    eng.chains.set(c.symbol, {
+      config: { name: c.symbol },
+      address: 'Lfixture',
+      currentBlock: { hash: c.hashHex, target: c.targetHex },
+      enabled: true,
+      blocksFound: 0,
+    });
+    eng.auxBlocks.set(c.symbol, {
+      hash: c.hashHex,
+      target: c.targetHex,
+      chainId: c.chainId,
+    });
+  }
+  return eng;
+}
+
+test('buildAuxMerkleTree returns a branch entry for every active chain', () => {
+  const eng = makeEngineWithChains([
+    { symbol: 'AAA', chainId: 0x01, hashHex: '11'.repeat(32), targetHex: 'ff'.repeat(32) },
+    { symbol: 'BBB', chainId: 0x02, hashHex: '22'.repeat(32), targetHex: 'ff'.repeat(32) },
+    { symbol: 'CCC', chainId: 0x03, hashHex: '33'.repeat(32), targetHex: 'ff'.repeat(32) },
+    { symbol: 'DDD', chainId: 0x04, hashHex: '44'.repeat(32), targetHex: 'ff'.repeat(32) },
+  ]);
+  const tree = eng.buildAuxMerkleTree();
+  assert(tree !== null, 'Tree should not be null');
+  assert(tree.branches instanceof Map, 'Tree should expose a branches Map');
+  for (const sym of ['AAA', 'BBB', 'CCC', 'DDD']) {
+    assert(tree.branches.has(sym), `Missing branch entry for ${sym}`);
+  }
+});
+
+test('Reconstructing root from leaf + branch + sideMask matches auxMerkleRoot (multi-chain)', () => {
+  const eng = makeEngineWithChains([
+    { symbol: 'AAA', chainId: 0x11, hashHex: 'aa'.repeat(32), targetHex: 'ff'.repeat(32) },
+    { symbol: 'BBB', chainId: 0x22, hashHex: 'bb'.repeat(32), targetHex: 'ff'.repeat(32) },
+    { symbol: 'CCC', chainId: 0x33, hashHex: 'cc'.repeat(32), targetHex: 'ff'.repeat(32) },
+    { symbol: 'DDD', chainId: 0x44, hashHex: 'dd'.repeat(32), targetHex: 'ff'.repeat(32) },
+  ]);
+  const tree = eng.buildAuxMerkleTree();
+  for (const [sym, info] of tree.branches) {
+    let h = Buffer.from(eng.auxBlocks.get(sym).hash, 'hex');
+    for (let lvl = 0; lvl < info.branch.length; lvl++) {
+      const isRight = (info.sideMask >> lvl) & 1;
+      h = isRight
+        ? sha256d(Buffer.concat([info.branch[lvl], h]))
+        : sha256d(Buffer.concat([h, info.branch[lvl]]));
+    }
+    assert(
+      h.equals(tree.auxMerkleRoot),
+      `Branch reconstruction for ${sym} did not match root`
+    );
+  }
+});
+
+test('Single-chain proof has empty branch when merkleSize=2 with one zero slot', () => {
+  // Force merkleSize=2 by registering exactly one chain
+  const eng = makeEngineWithChains([
+    { symbol: 'AAA', chainId: 0x01, hashHex: 'ee'.repeat(32), targetHex: 'ff'.repeat(32) },
+  ]);
+  const tree = eng.buildAuxMerkleTree();
+  assert(tree.auxMerkleSize === 2, `Expected merkleSize=2, got ${tree.auxMerkleSize}`);
+  const info = tree.branches.get('AAA');
+  assert(info.branch.length === 1, `Expected 1-level branch (sibling = zero hash), got ${info.branch.length}`);
+
+  // Verify reconstruction: hash(slot ordering) → root
+  let h = Buffer.from(eng.auxBlocks.get('AAA').hash, 'hex');
+  const isRight = info.sideMask & 1;
+  h = isRight
+    ? sha256d(Buffer.concat([info.branch[0], h]))
+    : sha256d(Buffer.concat([h, info.branch[0]]));
+  assert(h.equals(tree.auxMerkleRoot), 'Single-chain proof did not match root');
+});
+
+// ═══════════════════════════════════════════════════════
 // RESULTS
 // ═══════════════════════════════════════════════════════
 

--- a/tests/emulation-c.js
+++ b/tests/emulation-c.js
@@ -165,7 +165,7 @@ const secEngine = new SecurityEngine(
   {
     transport: { requireTls: false },
     protocol: { maxMessageBytes: 2048, maxWorkerLength: 96, maxPasswordLength: 64 },
-    auth: {},
+    auth: { secret: 'test-cookie-secret-with-at-least-32-chars-of-entropy' },
     fingerprint: { minShares: 500, bwhThreshold: 0.01, staleLimit: 0.20 },
     behavior: { maxSharesPerSec: 10, maxNtimeDeviation: 300, maxAddressesPerIp: 3, maxHashrateOscillation: 5 },
     rateLimit: { maxConnPerIp: 5, maxConnPerFleetIp: 100, maxShareRatePerMin: 600, maxConnRatePerMin: 30 },
@@ -458,6 +458,37 @@ test('Single-chain proof has empty branch when merkleSize=2 with one zero slot',
     ? sha256d(Buffer.concat([info.branch[0], h]))
     : sha256d(Buffer.concat([h, info.branch[0]]));
   assert(h.equals(tree.auxMerkleRoot), 'Single-chain proof did not match root');
+});
+
+// ═══════════════════════════════════════════════════════
+// C6b: COOKIE_SECRET REQUIRED (H-9)
+// ═══════════════════════════════════════════════════════
+
+console.log('\nC6b: Cookie Secret Enforcement\n');
+
+const { AuthLayer } = require('../src/pool/securityEngine');
+
+test('AuthLayer throws without a secret', () => {
+  let threw = false;
+  try { new AuthLayer({}); } catch (err) { threw = /COOKIE_SECRET/.test(err.message); }
+  assert(threw, 'Expected AuthLayer to throw on missing secret');
+});
+
+test('AuthLayer throws with too-short secret (<32 chars)', () => {
+  let threw = false;
+  try { new AuthLayer({ secret: 'short' }); } catch (err) { threw = /COOKIE_SECRET/.test(err.message); }
+  assert(threw, 'Expected AuthLayer to throw on short secret');
+});
+
+test('Two AuthLayers with same secret produce identical cookies for same client', () => {
+  const sec = 'a'.repeat(64); // 64 hex chars
+  const a1 = new AuthLayer({ secret: sec });
+  const a2 = new AuthLayer({ secret: sec });
+  // Force matching serverEpoch so cookie HMAC inputs are identical
+  a2.serverEpoch = a1.serverEpoch;
+  const c1 = a1.issueCookie('client-x');
+  const c2 = a2.issueCookie('client-x');
+  assert(c1 === c2, `Cookies must match across nodes with same secret+epoch (got ${c1} vs ${c2})`);
 });
 
 // ═══════════════════════════════════════════════════════

--- a/tests/emulation-c.js
+++ b/tests/emulation-c.js
@@ -388,6 +388,59 @@ test('Reconstructing root from leaf + branch + sideMask matches auxMerkleRoot (m
   }
 });
 
+test('Slot collision is escaped without linear probing (C-3)', () => {
+  // Pick chainIds that all map to the same slot for nonce=0, merkleSize=4.
+  // After C-3, the engine must escape the collision by either rotating
+  // merkleNonce or doubling the tree size — the post-condition is that
+  // every chain's placed slot matches _getAuxSlot(cid, size, nonce).
+  const probeEng = new AuxPowEngine({}, {});
+  const targetSlot = probeEng._getAuxSlot(1, 4, 0);
+  const colliders = [];
+  for (let cid = 1; cid < 1000 && colliders.length < 3; cid++) {
+    if (probeEng._getAuxSlot(cid, 4, 0) === targetSlot) colliders.push(cid);
+  }
+  assert(colliders.length === 3, `Expected to find 3 colliders, got ${colliders.length}`);
+
+  const eng = makeEngineWithChains(colliders.map((cid, i) => ({
+    symbol: `C${i}`,
+    chainId: cid,
+    hashHex: String((i + 1) * 11).padStart(2, '0').repeat(32).slice(0, 64),
+    targetHex: 'ff'.repeat(32),
+  })));
+  const tree = eng.buildAuxMerkleTree();
+  assert(tree !== null, 'Tree built');
+  assert(tree.branches.size === 3, `All 3 chains must be placed, got ${tree.branches.size}`);
+
+  // The daemon recomputes each chain's expected slot from chainId + nonce +
+  // merkleSize. Linear probing breaks this invariant; nonce rotation /
+  // tree doubling preserves it.
+  for (const [sym, info] of tree.branches) {
+    const cid = eng.auxBlocks.get(sym).chainId;
+    const expected = eng._getAuxSlot(cid, tree.auxMerkleSize, tree.merkleNonce);
+    assert(info.slot === expected,
+      `${sym} placed at slot ${info.slot}, but _getAuxSlot(${cid}, ${tree.auxMerkleSize}, ${tree.merkleNonce}) = ${expected}`);
+  }
+});
+
+test('Two colliding chains: merkleNonce rotates rather than doubling tree', () => {
+  // Two chains colliding at nonce=0 size=4 — should be escapable by nonce
+  // rotation alone for most chainId pairs.
+  const probeEng = new AuxPowEngine({}, {});
+  // chainId=2 → slot 0, chainId=6 → slot 0 at nonce=0, size=4
+  const eng = makeEngineWithChains([
+    { symbol: 'A', chainId: 2, hashHex: '11'.repeat(32), targetHex: 'ff'.repeat(32) },
+    { symbol: 'B', chainId: 6, hashHex: '22'.repeat(32), targetHex: 'ff'.repeat(32) },
+  ]);
+  const tree = eng.buildAuxMerkleTree();
+  assert(tree.branches.size === 2, 'Both chains placed');
+  // Verify daemon-side invariant
+  for (const [sym, info] of tree.branches) {
+    const cid = eng.auxBlocks.get(sym).chainId;
+    assert(info.slot === eng._getAuxSlot(cid, tree.auxMerkleSize, tree.merkleNonce),
+      `Slot mismatch for ${sym}`);
+  }
+});
+
 test('Single-chain proof has empty branch when merkleSize=2 with one zero slot', () => {
   // Force merkleSize=2 by registering exactly one chain
   const eng = makeEngineWithChains([

--- a/tests/emulation-c.js
+++ b/tests/emulation-c.js
@@ -461,6 +461,80 @@ test('Single-chain proof has empty branch when merkleSize=2 with one zero slot',
 });
 
 // ═══════════════════════════════════════════════════════
+// C7: BLOCK REWARD ROUTING — LTC_REWARD_ADDRESS (C-4)
+// ═══════════════════════════════════════════════════════
+
+console.log('\nC7: Reward Wallet Separation\n');
+
+const BlockTemplateManager = require('../src/blockchain/blockTemplate');
+const { addressToOutputScript } = require('../src/utils/addressCodec');
+
+// Two distinct, valid Litecoin addresses for the test.
+// (Generated deterministically from seeds via Base58Check; bech32 reward
+// + base58 fee covers both encoding paths in addressToOutputScript.)
+const REWARD_ADDR = 'ltc1qw508d6qejxtdg4y5r3zarvary0c5xw7kgmn4n9';
+const FEE_ADDR    = 'Lcyr7wgBHAU9xpSsPVpmAr1g8bKedPaGYR';
+
+test('_buildOutputScript(rewardAddress) produces the reward wallet\'s script (not fee)', () => {
+  const btm = new BlockTemplateManager(null, {
+    fee: 0.02,
+    feeAddress: FEE_ADDR,
+    rewardAddress: REWARD_ADDR,
+  });
+  const rewardScript = btm._buildOutputScript(REWARD_ADDR);
+  const feeScript    = btm._buildOutputScript(FEE_ADDR);
+  assert(!rewardScript.equals(feeScript),
+    'Reward and fee output scripts must differ when addresses differ');
+  assert(rewardScript.equals(addressToOutputScript(REWARD_ADDR)),
+    'Reward script must equal addressToOutputScript(LTC_REWARD_ADDRESS)');
+});
+
+test('_getCoinbaseParts throws when rewardAddress is missing', () => {
+  const btm = new BlockTemplateManager(null, {
+    fee: 0.02,
+    feeAddress: FEE_ADDR,
+    // no rewardAddress
+  });
+  btm.currentTemplate = {
+    coinbasevalue: 625000000,
+    height: 50000,
+    bits: '1d00ffff',
+    previousblockhash: '00'.repeat(32),
+    transactions: [],
+  };
+  btm.currentJobId = 'jobtest';
+  let threw = false;
+  try { btm._getCoinbaseParts(); } catch (err) {
+    threw = /LTC_REWARD_ADDRESS/.test(err.message);
+  }
+  assert(threw, 'Expected _getCoinbaseParts to throw on missing rewardAddress');
+});
+
+test('Coinbase output 1 (miner reward) script bytes match LTC_REWARD_ADDRESS', () => {
+  const btm = new BlockTemplateManager(null, {
+    fee: 0.02,
+    feeAddress: FEE_ADDR,
+    rewardAddress: REWARD_ADDR,
+  });
+  btm.currentTemplate = {
+    coinbasevalue: 625000000,
+    height: 50000,
+    bits: '1d00ffff',
+    previousblockhash: '00'.repeat(32),
+    transactions: [],
+  };
+  btm.currentJobId = 'jobtest';
+  const [cb1, cb2] = btm._getCoinbaseParts();
+  // The full coinbase = cb1 + extranonce1 + extranonce2 + cb2.
+  // Output 1's script bytes appear inside cb2; just assert addressToOutputScript
+  // bytes for the reward wallet appear in the coinbase, and the fee wallet's
+  // script does NOT appear at the same offset as before C-4.
+  const expectedRewardScript = addressToOutputScript(REWARD_ADDR);
+  assert(cb2.indexOf(expectedRewardScript) !== -1,
+    'Reward address output script not present in coinbase tail');
+});
+
+// ═══════════════════════════════════════════════════════
 // RESULTS
 // ═══════════════════════════════════════════════════════
 

--- a/tests/emulation-d.js
+++ b/tests/emulation-d.js
@@ -547,12 +547,62 @@ test('VarDiff adjusts up for fast shares', () => {
 });
 
 // ═══════════════════════════════════════════════════════
+// D14: PPLNS QUERY MUST FILTER BY status='valid' (C-1)
+// ═══════════════════════════════════════════════════════
+
+const pplnsAsyncTests = [];
+pplnsAsyncTests.push(async () => {
+  const queries = [];
+  const spyDb = {
+    query: async (sql, params) => {
+      queries.push({ sql, params });
+      // Return synthetic rows that would only contain valid shares
+      return { rows: [{ address: 'Lvalid01aaaaaaaaaaaaaaaaaaaaaaaaaa', total_diff: '300' }] };
+    },
+  };
+  const spyRedis = {
+    get: async () => null, set: async () => 'OK', del: async () => 1,
+    incrbyfloat: async () => '0',
+    pipeline: () => ({ hincrby: () => {}, incr: () => {}, set: () => {}, exec: async () => [] }),
+  };
+  const spyPP = new PaymentProcessor(mockRpc, spyDb, spyRedis, {
+    pplnsWindow: 100, poolFee: 0.02, minPayout: 0.001, fleetAddresses: new Set(),
+  }, null);
+
+  await spyPP._calculatePPLNS({ height: 50000 });
+
+  const pplnsQ = queries.find(q => /SUM\s*\(\s*difficulty\s*\)/i.test(q.sql));
+  if (!pplnsQ) {
+    console.log('  ❌ PPLNS SQL not captured by spy');
+    failed++;
+    return;
+  }
+  if (!/AND\s+status\s*=\s*'valid'/i.test(pplnsQ.sql)) {
+    console.log(`  ❌ PPLNS query missing status='valid' filter: ${pplnsQ.sql}`);
+    failed++;
+    return;
+  }
+  console.log('  ✅ PPLNS query filters by status=\'valid\' (C-1)');
+  passed++;
+});
+
+// ═══════════════════════════════════════════════════════
 // RUN ASYNC TESTS + SUMMARY
 // ═══════════════════════════════════════════════════════
 
 (async () => {
   console.log('\nD9: Payment Retry (async)\n');
   for (const fn of asyncTests) {
+    try {
+      await fn();
+    } catch (err) {
+      console.log(`  ❌ Async test failed: ${err.message}`);
+      failed++;
+    }
+  }
+
+  console.log('\nD14: PPLNS Status Filter (async)\n');
+  for (const fn of pplnsAsyncTests) {
     try {
       await fn();
     } catch (err) {

--- a/tests/emulation-d.js
+++ b/tests/emulation-d.js
@@ -548,7 +548,48 @@ test('VarDiff adjusts up for fast shares', () => {
 
 // ═══════════════════════════════════════════════════════
 // D14: PPLNS QUERY MUST FILTER BY status='valid' (C-1)
+// D15: PAYMENT RECONCILIATION ON STARTUP (C-5)
 // ═══════════════════════════════════════════════════════
+
+// Helper to build a pending-payments fixture DB
+function makePendingDb(rows, captureUpdates) {
+  return {
+    query: async (sql, params) => {
+      if (/SELECT\s+block_height/i.test(sql) && /pending/i.test(sql)) {
+        // Group by block_height
+        const groups = new Map();
+        for (const r of rows) {
+          if (r.status !== 'pending' || r.coin !== 'LTC') continue;
+          if (!groups.has(r.block_height)) {
+            groups.set(r.block_height, { block_height: r.block_height, ids: [], addrs: [], amounts: [] });
+          }
+          const g = groups.get(r.block_height);
+          g.ids.push(r.id);
+          g.addrs.push(r.address);
+          g.amounts.push(String(r.amount));
+        }
+        return { rows: Array.from(groups.values()) };
+      }
+      if (/UPDATE\s+payments\s+SET\s+status='sent'/i.test(sql)) {
+        captureUpdates.push({ kind: 'sent', txid: params[0], ids: params[1] });
+        for (const r of rows) {
+          if (params[1].includes(r.id)) { r.status = 'sent'; r.txid = params[0]; }
+        }
+        return { rowCount: params[1].length };
+      }
+      if (/UPDATE\s+payments\s+SET\s+status='failed'/i.test(sql)) {
+        captureUpdates.push({ kind: 'failed', ids: params ? params[0] : null });
+        for (const r of rows) {
+          if (!params || params[0].includes(r.id)) {
+            if (r.status === 'pending' && r.coin === 'LTC') r.status = 'failed';
+          }
+        }
+        return { rowCount: rows.length };
+      }
+      return { rows: [], rowCount: 0 };
+    },
+  };
+}
 
 const pplnsAsyncTests = [];
 pplnsAsyncTests.push(async () => {
@@ -586,6 +627,90 @@ pplnsAsyncTests.push(async () => {
   passed++;
 });
 
+const reconcileAsyncTests = [];
+
+// Positive: matching wallet tx → pending → sent
+reconcileAsyncTests.push(async () => {
+  const rows = [
+    { id: 1, address: 'LrecA00000000000000000000000000000', amount: 1.25, block_height: 60001, status: 'pending', coin: 'LTC' },
+    { id: 2, address: 'LrecB00000000000000000000000000000', amount: 0.50, block_height: 60001, status: 'pending', coin: 'LTC' },
+  ];
+  const updates = [];
+  const db = makePendingDb(rows, updates);
+  const rpc = {
+    listRecentTransactions: async () => ([
+      // Wallet returns sends with negative amount
+      { category: 'send', address: 'LrecA00000000000000000000000000000', amount: -1.25, txid: 'tx_recon_001' },
+      { category: 'send', address: 'LrecB00000000000000000000000000000', amount: -0.50, txid: 'tx_recon_001' },
+    ]),
+  };
+  const pp = new PaymentProcessor(rpc, db, mockRedis, {
+    pplnsWindow: 100, poolFee: 0.02, minPayout: 0.001, fleetAddresses: new Set(),
+  }, null);
+  await pp._reconcilePending();
+  const sentUpd = updates.find(u => u.kind === 'sent');
+  if (!sentUpd || sentUpd.txid !== 'tx_recon_001') {
+    console.log(`  ❌ C-5 positive: expected sent UPDATE with tx_recon_001, got ${JSON.stringify(updates)}`);
+    failed++;
+    return;
+  }
+  if (rows.some(r => r.status !== 'sent')) {
+    console.log(`  ❌ C-5 positive: rows not updated to sent: ${JSON.stringify(rows)}`);
+    failed++;
+    return;
+  }
+  console.log('  ✅ Pending → sent when wallet TX matches recipient set (C-5)');
+  passed++;
+});
+
+// Negative: no matching wallet tx → pending → failed
+reconcileAsyncTests.push(async () => {
+  const rows = [
+    { id: 10, address: 'LrecC00000000000000000000000000000', amount: 0.10, block_height: 60002, status: 'pending', coin: 'LTC' },
+  ];
+  const updates = [];
+  const db = makePendingDb(rows, updates);
+  const rpc = { listRecentTransactions: async () => ([]) };
+  const pp = new PaymentProcessor(rpc, db, mockRedis, {
+    pplnsWindow: 100, poolFee: 0.02, minPayout: 0.001, fleetAddresses: new Set(),
+  }, null);
+  await pp._reconcilePending();
+  const failedUpd = updates.find(u => u.kind === 'failed');
+  if (!failedUpd) {
+    console.log(`  ❌ C-5 negative: expected failed UPDATE, got ${JSON.stringify(updates)}`);
+    failed++;
+    return;
+  }
+  if (rows[0].status !== 'failed') {
+    console.log(`  ❌ C-5 negative: row not marked failed: ${JSON.stringify(rows)}`);
+    failed++;
+    return;
+  }
+  console.log('  ✅ Pending → failed when no wallet TX matches (C-5)');
+  passed++;
+});
+
+// RPC failure: wallet listtransactions throws → bulk pending → failed
+reconcileAsyncTests.push(async () => {
+  const rows = [
+    { id: 20, address: 'LrecD00000000000000000000000000000', amount: 0.20, block_height: 60003, status: 'pending', coin: 'LTC' },
+  ];
+  const updates = [];
+  const db = makePendingDb(rows, updates);
+  const rpc = { listRecentTransactions: async () => { throw new Error('rpc-down'); } };
+  const pp = new PaymentProcessor(rpc, db, mockRedis, {
+    pplnsWindow: 100, poolFee: 0.02, minPayout: 0.001, fleetAddresses: new Set(),
+  }, null);
+  await pp._reconcilePending();
+  if (rows[0].status !== 'failed') {
+    console.log(`  ❌ C-5 rpc-fail: row not marked failed on RPC error: ${JSON.stringify(rows)}`);
+    failed++;
+    return;
+  }
+  console.log('  ✅ RPC failure during reconcile downgrades pending → failed (C-5)');
+  passed++;
+});
+
 // ═══════════════════════════════════════════════════════
 // RUN ASYNC TESTS + SUMMARY
 // ═══════════════════════════════════════════════════════
@@ -603,6 +728,16 @@ pplnsAsyncTests.push(async () => {
 
   console.log('\nD14: PPLNS Status Filter (async)\n');
   for (const fn of pplnsAsyncTests) {
+    try {
+      await fn();
+    } catch (err) {
+      console.log(`  ❌ Async test failed: ${err.message}`);
+      failed++;
+    }
+  }
+
+  console.log('\nD15: Payment Reconciliation (async)\n');
+  for (const fn of reconcileAsyncTests) {
     try {
       await fn();
     } catch (err) {

--- a/tests/emulation.js
+++ b/tests/emulation.js
@@ -354,7 +354,7 @@ const AuditLog = require('../src/pool/auditLog');
 
 // C1: Miner Registry — Model Detection
 console.log('C1: Miner Model Detection');
-const registry = new MinerRegistry();
+const registry = MinerRegistry;
 
 const l9 = registry.identify('bitmain-antminer-l9/1.0.3');
 assert(l9 !== null, 'Detects Antminer L9');


### PR DESCRIPTION
Closes the 5 CRITICAL + 9 HIGH + 7 MEDIUM findings from the Opus 4.7 security review of `3e35a34`. Each finding is one commit, message format `fix(sec): <id> <one-line>`. `npm test` was run after every commit.

## Test posture

- **Baseline at branch start:** 68 tests reporting passed (171 actually pass, but `tests/emulation.js` crashed at line 357 on a stale `new MinerRegistry()` from the v0.8.2 singleton conversion). Fixed in the precondition commit `b241639`.
- **Final:** **186 passed**, 6 pre-existing failures unchanged. Those 6 are stale ASIC-registry assertions from the v0.8.2 expansion (`expectedHashrate` field name / model count drift) and are **out of security scope** — flagged for a follow-up PR.
- `npm audit --audit-level=high` reports **0 vulnerabilities**.

## CRITICAL (5)

| ID | Fix | Test added |
|----|-----|------------|
| **C-1** | PPLNS query now filters `AND status = 'valid'`; new partial index `idx_shares_height_status` (migration 013) | D14 SQL-spy |
| **C-2** | `buildAuxMerkleTree` retains all levels, exposes per-chain branches; `_buildAuxPowProof` serializes the real branch (not zeros) | C6 — reconstruct root from branch + sideMask matches `auxMerkleRoot` |
| **C-3** | Slot collision rotates `merkleNonce` (max 65536 tries) instead of linear probing; falls back to doubling tree size; preserves the daemon-side `_getAuxSlot` invariant | C6 — slot ↔ formula match for both 2-chain and 3-chain pathological cases |
| **C-4** | New required `LTC_REWARD_ADDRESS`; coinbase Output 1 routes to it (was `feeAddress` or placeholder); `validateConfig` rejects when reward = fee | C7 — coinbase output script bytes match the reward wallet |
| **C-5** | `_reconcilePending` at startup walks pending payment rows, matches against `listtransactions`, marks sent or failed; `start()` is now async | D15 — positive, negative, RPC-fail |

⚠ **Operator action for C-4:** Generate a Litecoin address and set `LTC_REWARD_ADDRESS` in the production `.env` before deploy. The pool refuses to start without it.

## HIGH (9)

| ID | Fix |
|----|-----|
| **H-1** | Remove dead L3 cookie verification (Stratum V1 has no echo channel); `getStatus()` reports L3 as `deferred`; README softened |
| **H-2** | Drop unused `bignum` (CVE GHSA-6429-3g3w-6mw5); upgrade `nodemailer` 6.10 → 8.0.7 (closes 2 SMTP-injection advisories) |
| **H-3** | `litecoind` `-rpcallowip` narrowed from `0.0.0.0/0` to `172.28.0.0/16` (luxxpool-net subnet) |
| **H-4** | **Docs only:** `docs/engineering/DEPLOYMENT.md` — rpcauth migration runbook for OVH provisioning. No compose change. |
| **H-5** | `/api/v1/miners/active` strips `ip`, `id`, truncates worker/address for public callers; admin token returns full data |
| **H-6** | Per-address rate limit (30/60s) on `/api/v1/miner/:address*`; 60s not-found cache |
| **H-7** | Validate LTC addresses on POST/DELETE `/fleet/address`; octet-bounded IPv4 regex; clamp capacity to 1..10000; emit `FLEET_001` / `FLEET_002` |
| **H-8** | New `src/api/middleware/adminAuth.js` using `crypto.timingSafeEqual`; consolidates 3 duplicated route copies (fleet, security, dashboard) |
| **H-9** | `COOKIE_SECRET` required at startup, ≥32 chars; `AuthLayer` throws on missing/short secret instead of falling back to per-process random |

## MEDIUM (7)

| ID | Fix |
|----|-----|
| **M-1** | `submitBlock` per-attempt 30s AbortController ceiling + distinct `BLOCK_RPC_TIMEOUT` event |
| **M-2** | `sendMany` defaults `minconf=1` (prevents spending unconfirmed coinbase UTXOs); DEPLOYMENT.md compatibility note |
| **M-4** | Clamp `?hours` query param to 1..720 on hashrate endpoints |
| **M-5** | `safeHexToBuffer(hex, label, expectedBytes)` helper applied at four AuxPoW trust boundaries |
| **M-7** | `cap_drop: ALL` + `no-new-privileges` on every compose service (postgres, redis, litecoind in addition to pool) |
| **M-8** | Reject Bitcoin P2SH version byte (`0x05`) in `addressToOutputScript` — was silently accepted as Litecoin P2SH |
| **M-11** | AuxPoW lock acquire failure now rejects submission instead of proceeding lock-less (avoids daemon banscore from duplicate submits) |

**Auto-resolved:** M-3 by H-7, M-9 by C-4, M-10 by H-1.

**Deferred:** M-6 (image digest pinning — wants a separate Litecoin Core version-policy decision); all 6 LOW (L-3, L-5 auto-resolved; L-1 tightening ntime tolerance needs a soak; L-2, L-4, L-6 hygiene only).

## Verification gate (run on this branch)

```bash
npm test                        # 186 passed, 6 pre-existing
npm audit --audit-level=high    # 0 vulnerabilities
grep -rn "TODO\|FIXME" --include='*.js' src/      # empty
grep -n "AND status = 'valid'" src/payment/paymentProcessor.js   # C-1
grep -n "auxBranchInfo"        src/blockchain/auxpow.js          # C-2
grep -n "MAX_NONCE_TRIES"      src/blockchain/auxpow.js          # C-3
grep -n "rewardAddress"        src/blockchain/blockTemplate.js   # C-4
grep -n "_reconcilePending"    src/payment/paymentProcessor.js   # C-5
```

## Tag

`v0.8.3` is created locally on commit `14a278f` (the version bump). Tag push was blocked by the working environment (HTTP 403); operator should re-tag from `main` after merge.

## Pre-deploy checklist for OVH

- [ ] Generate `LTC_REWARD_ADDRESS` and add to production `.env` (C-4)
- [ ] Generate `COOKIE_SECRET` via `openssl rand -hex 32` and add to `.env` (H-9)
- [ ] Apply rpcauth migration per `docs/engineering/DEPLOYMENT.md` (H-4)
- [ ] Run migration 013 against the production DB (`npm run migrate`)
- [ ] Pin litecoind image digest (M-6, deferred from this PR)

Draft PR — review and merge to `main` before deploying Tuesday.

---
_Generated by [Claude Code](https://claude.ai/code/session_012oERfGwknt9tYki7cmkw75)_